### PR TITLE
Fix expired coordinates occasionally being 100% accurate

### DIFF
--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -1697,7 +1697,7 @@ namespace HyperJump
 		if (coords.time < time(0))
 		{
 			PrintUserCmdText(iClientID, L"Warning old coordinates detected. Jump not recommended");
-			coords.accuracy *= rand()%7;
+			coords.accuracy *= rand()%6 + 1;
 		}
 		
 		jd.iTargetSystem = coords.system;


### PR DESCRIPTION
There was a bug where expired coordinates had a 1 in 7 chance of being 100% accurate due to `rand()%7` returning a value between 0 and 6, not the intended 1 and 6.