### PR TITLE
Docking modules fix

### DIFF
--- a/Plugins/Public/mobiledocking_plugin/Main.cpp
+++ b/Plugins/Public/mobiledocking_plugin/Main.cpp
@@ -156,30 +156,12 @@ void __stdcall BaseExit(uint iBaseID, uint iClientID)
 
 }
 
-void __stdcall DisConnect(uint iClientID, enum EFLConnection p2)
-{
-	returncode = DEFAULT_RETURNCODE;
-
-	// If the ship was docked to someone, erase it from docked ship list.
-	if (mobiledockClients[iClientID].mobileDocked)
-	{
-		uint carrierClientID = HkGetClientIdFromCharname(mobiledockClients[iClientID].wscDockedWithCharname);
-
-		// If carrier is present at server - do it, if not - whatever. Plugin erases all associated client data after disconnect. 
-		if (carrierClientID != -1)
-		{
-			wstring charname = (const wchar_t*)Players.GetActiveCharacterName(iClientID);
-			mobiledockClients[carrierClientID].mapDockedShips.erase(charname);
-			mobiledockClients[carrierClientID].iDockingModulesAvailable++;
-		}
-	}
-}
-
 // Temporary storage for client data to be handled in LaunchPosHook.
 CLIENT_DATA undockingShip;
 
 void __stdcall PlayerLaunch(unsigned int iShip, unsigned int client)
 {
+
 	returncode = DEFAULT_RETURNCODE;
 
 	uint carrier_client = HkGetClientIdFromCharname(mobiledockClients[client].wscDockedWithCharname);
@@ -479,7 +461,10 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 			// Force the docked ship to launch.
 			UpdateCarrierLocationInformation(iDockedClientID, carrierShip);
 			ForceLaunch(iDockedClientID);
-			DisConnect(iDockedClientID, EFLConnection());
+
+			// Remove charname from carrier's mapDockedShips.
+			mobiledockClients[client].mapDockedShips.erase(charname);
+			mobiledockClients[client].iDockingModulesAvailable++;
 		}
 
 		return true;
@@ -556,6 +541,25 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 		return true;
 	}
 	return false;
+}
+
+void __stdcall DisConnect(uint iClientID, enum EFLConnection p2)
+{
+	returncode = DEFAULT_RETURNCODE;
+
+	// If the ship was docked to someone, erase it from docked ship list.
+	if (mobiledockClients[iClientID].mobileDocked)
+	{
+		uint carrierClientID = HkGetClientIdFromCharname(mobiledockClients[iClientID].wscDockedWithCharname);
+
+		// If carrier is present at server - do it, if not - whatever. Plugin erases all associated client data after disconnect. 
+		if (carrierClientID != -1)
+		{
+			wstring charname = (const wchar_t*)Players.GetActiveCharacterName(iClientID);
+			mobiledockClients[carrierClientID].mapDockedShips.erase(charname);
+			mobiledockClients[carrierClientID].iDockingModulesAvailable++;
+		}
+	}
 }
 
 void __stdcall CharacterSelect_AFTER(struct CHARACTER_ID const & cId, unsigned int iClientID)

--- a/Plugins/Public/mobiledocking_plugin/Main.cpp
+++ b/Plugins/Public/mobiledocking_plugin/Main.cpp
@@ -15,81 +15,7 @@ vector<uint> dockingModuleEquipmentIds;
 // Above how much cargo capacity, should a ship be rejected as a docking user?
 int cargoCapacityLimit = 275;
 
-// How much time will player be given before kick if carrier wants to jettison him.
-int jettisonKickTime = 15;
-
-uint connSystemID = CreateID("li06");
-
-// Delayed actions, which need to be done. Look at HkTimerCheckKick().
-vector<ActionJettison> jettisonList;
-
-void HkTimerCheckKick()
-{
-	returncode = DEFAULT_RETURNCODE;
-
-	for (vector<ActionJettison>::iterator it = jettisonList.begin(); it != jettisonList.end(); )
-	{
-		it->timeLeft--;
-		if (it->timeLeft == 0)
-		{
-			uint checkCarrierClientID = HkGetClientIdFromCharname(it->carrierCharname);
-			uint checkDockedClientID = HkGetClientIdFromCharname(it->dockedCharname);
-
-			// If both carrier and docked ship are still at server.
-			if (checkDockedClientID != -1 && checkCarrierClientID != -1)
-			{
-				// If the client is still docked
-				if (mobiledockClients[checkDockedClientID].wscDockedWithCharname == it->carrierCharname)
-				{
-					HkKickReason(ARG_CLIENTID(checkDockedClientID), L"Forced undocking.");
-
-					// If carrier died, we don't need this message.
-					if(!mobiledockClients[checkDockedClientID].carrierDied)
-						PrintUserCmdText(checkCarrierClientID, L"Jettisoning ship...");
-				}
-			}
-
-			it = jettisonList.erase(it);
-		}
-		else
-		{
-			it++;
-		}
-	}
-}
-
-// Easy creation of delayed action.
-void DelayedJettison(int delayTimeSecond, wstring carrierCharname, wstring dockedCharname)
-{
-	ActionJettison action;
-	action.timeLeft = delayTimeSecond;
-	action.carrierCharname = carrierCharname;
-	action.dockedCharname = dockedCharname;
-	jettisonList.push_back(action);
-}
-
-void JettisonShip(uint carrierClientID, uint dockedClientID)
-{
-	const wchar_t* carrierCharname = (const wchar_t*)Players.GetActiveCharacterName(carrierClientID);
-	const wchar_t* dockedCharname = (const wchar_t*)Players.GetActiveCharacterName(dockedClientID);
-
-	if (dockedClientID != -1)
-	{
-		if (!mobiledockClients[dockedClientID].carrierDied)
-		{
-			PrintUserCmdText(carrierClientID, L"Ship warned. If it doesn't undock in %i seconds, it will be kicked by force.", jettisonKickTime);
-			PrintUserCmdText(dockedClientID, L"Carrier wants to jettison your ship. Undock willingly or you will be kicked after %i seconds.", jettisonKickTime);
-		}
-		else
-		{
-			PrintUserCmdText(dockedClientID, L"ALERT! Carrier ship is being destroyed. Launch ship or you will die in explosion.");
-		}
-		pub::Audio::PlaySoundEffect(dockedClientID, CreateID("rtc_klaxon_loop"));
-
-		// Create delayed action.
-		DelayedJettison(jettisonKickTime, carrierCharname, dockedCharname);
-	}
-}
+map<uint, DEFERREDJUMPS> mapDeferredJumps;
 
 // Returns count of installed docking modules on ship of specific client.
 uint GetInstalledModules(uint iClientID)
@@ -111,35 +37,15 @@ uint GetInstalledModules(uint iClientID)
 	return modules;
 }
 
-void LogCheater(uint client, const wstring &reason)
+void ForceLaunch(uint client)
 {
-	CAccount *acc = Players.FindAccountFromClientID(client);
+	mobiledockClients[client].forceUndocking = true;
 
-	if (!HkIsValidClientID(client) || !acc)
-	{
-		AddLog("ERROR: invalid parameter in log cheater, clientid=%u acc=%08x reason=%s", client, acc, wstos(reason).c_str());
-		return;
-	}
+	mapDeferredJumps[client].system = mobiledockClients[client].carrierSystem;
+	mapDeferredJumps[client].pos = mobiledockClients[client].carrierPos;
+	mapDeferredJumps[client].ornt = mobiledockClients[client].carrierRot;
 
-	// Set the kick timer to kick this player. We do this to break potential
-	// stack corruption.
-	HkDelayedKick(client, 1);
-
-	// Ban the account.
-	flstr *flStr = CreateWString(acc->wszAccID);
-	Players.BanAccount(*flStr, true);
-	FreeWString(flStr);
-
-	// Overwrite the ban file so that it contains the ban reason
-	wstring wscDir;
-	HkGetAccountDirName(acc, wscDir);
-	string scBanPath = scAcctPath + wstos(wscDir) + "\\banned";
-	FILE *file = fopen(scBanPath.c_str(), "wbe");
-	if (file)
-	{
-		fprintf(file, "Autobanned by Docking Module\n");
-		fclose(file);
-	}
+	PrintUserCmdText(client, L" ChangeSys %u", mobiledockClients[client].carrierSystem);
 }
 
 void UpdateCarrierLocationInformation(uint dockedClientId, uint carrierShip)
@@ -250,12 +156,30 @@ void __stdcall BaseExit(uint iBaseID, uint iClientID)
 
 }
 
+void __stdcall DisConnect(uint iClientID, enum EFLConnection p2)
+{
+	returncode = DEFAULT_RETURNCODE;
+
+	// If the ship was docked to someone, erase it from docked ship list.
+	if (mobiledockClients[iClientID].mobileDocked)
+	{
+		uint carrierClientID = HkGetClientIdFromCharname(mobiledockClients[iClientID].wscDockedWithCharname);
+
+		// If carrier is present at server - do it, if not - whatever. Plugin erases all associated client data after disconnect. 
+		if (carrierClientID != -1)
+		{
+			wstring charname = (const wchar_t*)Players.GetActiveCharacterName(iClientID);
+			mobiledockClients[carrierClientID].mapDockedShips.erase(charname);
+			mobiledockClients[carrierClientID].iDockingModulesAvailable++;
+		}
+	}
+}
+
 // Temporary storage for client data to be handled in LaunchPosHook.
 CLIENT_DATA undockingShip;
 
 void __stdcall PlayerLaunch(unsigned int iShip, unsigned int client)
 {
-
 	returncode = DEFAULT_RETURNCODE;
 
 	uint carrier_client = HkGetClientIdFromCharname(mobiledockClients[client].wscDockedWithCharname);
@@ -270,30 +194,15 @@ void __stdcall PlayerLaunch(unsigned int iShip, unsigned int client)
 		// Set last base to last real base this ship was on. POB support will be added in 0.9.X version.
 		Players[client].iLastBaseID = mobiledockClients[client].iLastBaseID;
 
-		// Check if carrier died.
-		if (mobiledockClients[client].carrierDied)
+		// Check if carrier jettisons this ship.
+		if (mobiledockClients[client].forceUndocking)
 		{
-			// If died carrier and docked ship are in same system.
-			if (Players[client].iSystemID == mobiledockClients[client].carrierSystem)
-			{
-				// Now that the data is prepared, send the player to the carrier's location
-				undockingShip = mobiledockClients[client];
+			// Now that the data is prepared, send the player to the carrier's location
+			undockingShip = mobiledockClients[client];
 
-				// Clear the client out of the mobiledockClients now that it's no longer docked
-				mobiledockClients.erase(client);
-			}
-			// If not - redirect to proxy base in carrier's system.
-			else
-			{
-				wstring scProxyBase = HkGetSystemNickByID(mobiledockClients[client].carrierSystem) + L"_proxy_base";
-				if (pub::GetBaseID(mobiledockClients[client].proxyBaseID, (wstos(scProxyBase)).c_str()) == -4)
-				{
-					PrintUserCmdText(client, L"No proxy base in system detected. Contact a developer about this please. Required base: %ws", scProxyBase);
-					return;
-				}
-
-				mobiledockClients[client].carrierSystem = -1;
-			}
+			// Clear the client out of the mobiledockClients now that it's no longer docked
+			mobiledockClients.erase(client);
+			
 			return;
 		}
 		else if (carrier_client == -1)
@@ -352,39 +261,6 @@ void __stdcall PlayerLaunch(unsigned int iShip, unsigned int client)
 		{
 			mobiledockClients[client].carrierSystem = -1;
 		}
-
-		//Conn exploiting check
-		if (Players[client].iSystemID == connSystemID)
-		{
-			wstring playerName = (const wchar_t*)Players.GetActiveCharacterName(client);
-			list<CARGO_INFO> cargo;
-			int holdSize = 0;
-
-			HkEnumCargo(playerName, cargo, holdSize);
-
-			for (list<CARGO_INFO>::const_iterator it = cargo.begin(); it != cargo.end(); ++it)
-			{
-				const CARGO_INFO & item = *it;
-
-				bool flag = false;
-				pub::IsCommodity(item.iArchID, flag);
-
-				// Some commodity present.
-				if (flag)
-				{
-					pub::Player::SendNNMessage(client, pub::GetNicknameId("nnv_anomaly_detected"));
-					wstring wscMsgU = L"MF: %name has been banned. (Type 6)";
-					wscMsgU = ReplaceStr(wscMsgU, L"%name", playerName.c_str());
-
-					HkMsgU(wscMsgU);
-
-					wstring wscMsgLog = L"<%sender> was banned for undocking from a carrier in conn with cargo.";
-					wscMsgLog = ReplaceStr(wscMsgLog, L"%sender", playerName.c_str());
-
-					LogCheater(client, wscMsgLog);
-				}
-			}
-		}
 	}
 }
 
@@ -418,14 +294,11 @@ void __stdcall PlayerLaunch_AFTER(unsigned int ship, unsigned int client)
 	// Land ship to proxy base in carrier's system if they are in different systems.
 	if (mobiledockClients[client].carrierSystem == -1)
 	{
-		if (!mobiledockClients[client].carrierDied)
+		string scProxyBase = HkGetPlayerSystemS(HkGetClientIdFromCharname(mobiledockClients[client].wscDockedWithCharname)) + "_proxy_base";
+		if (pub::GetBaseID(mobiledockClients[client].proxyBaseID, scProxyBase.c_str()) == -4)
 		{
-			string scProxyBase = HkGetPlayerSystemS(HkGetClientIdFromCharname(mobiledockClients[client].wscDockedWithCharname)) + "_proxy_base";
-			if (pub::GetBaseID(mobiledockClients[client].proxyBaseID, scProxyBase.c_str()) == -4)
-			{
-				PrintUserCmdText(client, L"No proxy base in system detected. Contact a developer about this please. Required base: %s", scProxyBase);
-				return;
-			}
+			PrintUserCmdText(client, L"No proxy base in system detected. Contact a developer about this please. Required base: %s", scProxyBase);
+			return;
 		}
 
 		pub::Player::ForceLand(client, mobiledockClients[client].proxyBaseID);
@@ -528,13 +401,10 @@ void __stdcall ShipDestroyed(DamageList *_dmg, DWORD *ecx, uint kill)
 					// Update the coordinates the given ship should launch to.
 					UpdateCarrierLocationInformation(iDockedClientID, cship->get_position(), cship->get_orientation());
 
-					// Carrier is no more. Set the flag.
-					mobiledockClients[iDockedClientID].carrierDied = true;
-
 					// Due to the carrier not existing anymore, we have to pull the system information from the carriers historical location.
 					mobiledockClients[iDockedClientID].carrierSystem = cship->iSystem;
 
-					JettisonShip(client, iDockedClientID);
+					ForceLaunch(iDockedClientID);
 				}
 
 				// Clear the carrier from the list
@@ -606,11 +476,10 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 		const uint iDockedClientID = HkGetClientIdFromCharname(charname);
 		if(iDockedClientID)
 		{
-			// Update the client with the current carrier location
+			// Force the docked ship to launch.
 			UpdateCarrierLocationInformation(iDockedClientID, carrierShip);
-
-			// Force the docked ship to launch. The teleport coordinates have been set by the previous method
-			JettisonShip(client, iDockedClientID);
+			ForceLaunch(iDockedClientID);
+			DisConnect(iDockedClientID, EFLConnection());
 		}
 
 		return true;
@@ -653,16 +522,6 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 			return true;
 		}
 
-		// Check if we're in conn. If so, reject the request
-		uint clientSystem;
-		pub::SpaceObj::GetSystem(client, clientSystem);
-		if(clientSystem == connSystemID)
-		{
-			mapPendingDockingRequests.erase(iTargetClientID);
-			PrintUserCmdText(client, L"You cannot dock in Connecticut.");
-			return true;
-		}
-
 		// The client is free to dock, erase from the pending list and handle
 		mapPendingDockingRequests.erase(iTargetClientID);
 
@@ -699,25 +558,6 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 	return false;
 }
 
-void __stdcall DisConnect(uint iClientID, enum EFLConnection p2)
-{
-	returncode = DEFAULT_RETURNCODE;
-
-	// If the ship was docked to someone, erase it from docked ship list.
-	if (mobiledockClients[iClientID].mobileDocked)
-	{
-		uint carrierClientID = HkGetClientIdFromCharname(mobiledockClients[iClientID].wscDockedWithCharname);
-
-		// If carrier is present at server - do it, if not - whatever. Plugin erases all associated client data after disconnect. 
-		if (carrierClientID != -1 && !mobiledockClients[iClientID].carrierDied)
-		{
-			wstring charname = (const wchar_t*)Players.GetActiveCharacterName(iClientID);
-			mobiledockClients[carrierClientID].mapDockedShips.erase(charname);
-			mobiledockClients[carrierClientID].iDockingModulesAvailable++;
-		}
-	}
-}
-
 void __stdcall CharacterSelect_AFTER(struct CHARACTER_ID const & cId, unsigned int iClientID)
 {
 	// Erase all plugin info associated with the client in case if the person has switched characters to prevent any bugs.
@@ -727,6 +567,70 @@ void __stdcall CharacterSelect_AFTER(struct CHARACTER_ID const & cId, unsigned i
 	// Update count of installed modules in case if client left his ship in open space before.
 	mobiledockClients[iClientID].iDockingModulesAvailable = mobiledockClients[iClientID].iDockingModulesInstalled = GetInstalledModules(iClientID);
 }
+
+void __stdcall SystemSwitchOutComplete(unsigned int iShip, unsigned int iClientID)
+{
+	if (mapDeferredJumps.find(iClientID) == mapDeferredJumps.end())
+		return;
+
+	static PBYTE SwitchOut = 0;
+
+	if (!SwitchOut)
+	{
+		SwitchOut = (PBYTE)hModServer + 0xf600;
+
+		DWORD dummy;
+		VirtualProtect(SwitchOut + 0xd7, 200, PAGE_EXECUTE_READWRITE, &dummy);
+	}
+
+	// Patch the system switch out routine to put the ship in a system of our choosing.
+
+	SwitchOut[0x0d7] = 0xeb;				// ignore exit object
+	SwitchOut[0x0d8] = 0x40;
+	SwitchOut[0x119] = 0xbb;				// set the destination system
+	*(PDWORD)(SwitchOut + 0x11a) = mapDeferredJumps[iClientID].system;
+	SwitchOut[0x266] = 0x45;				// don't generate warning
+	*(float*)(SwitchOut + 0x2b0) = mapDeferredJumps[iClientID].pos.z;		// set entry location
+	*(float*)(SwitchOut + 0x2b8) = mapDeferredJumps[iClientID].pos.y;
+	*(float*)(SwitchOut + 0x2c0) = mapDeferredJumps[iClientID].pos.x;
+	*(float*)(SwitchOut + 0x2c8) = mapDeferredJumps[iClientID].ornt.data[2][2];
+	*(float*)(SwitchOut + 0x2d0) = mapDeferredJumps[iClientID].ornt.data[1][1];
+	*(float*)(SwitchOut + 0x2d8) = mapDeferredJumps[iClientID].ornt.data[0][0];
+	*(float*)(SwitchOut + 0x2e0) = mapDeferredJumps[iClientID].ornt.data[2][1];
+	*(float*)(SwitchOut + 0x2e8) = mapDeferredJumps[iClientID].ornt.data[2][0];
+	*(float*)(SwitchOut + 0x2f0) = mapDeferredJumps[iClientID].ornt.data[1][2];
+	*(float*)(SwitchOut + 0x2f8) = mapDeferredJumps[iClientID].ornt.data[1][0];
+	*(float*)(SwitchOut + 0x300) = mapDeferredJumps[iClientID].ornt.data[0][2];
+	*(float*)(SwitchOut + 0x308) = mapDeferredJumps[iClientID].ornt.data[0][1];
+	*(PDWORD)(SwitchOut + 0x388) = 0x03ebc031;		// ignore entry object
+
+	mapDeferredJumps.erase(iClientID);
+	pub::SpaceObj::SetInvincible(iShip, false, false, 0);
+	Server.SystemSwitchOutComplete(iShip, iClientID);
+
+	SwitchOut[0x0d7] = 0x0f;
+	SwitchOut[0x0d8] = 0x84;
+	SwitchOut[0x119] = 0x87;
+	*(PDWORD)(SwitchOut + 0x11a) = 0x1b8;
+	*(PDWORD)(SwitchOut + 0x25d) = 0x1cf7f;
+	SwitchOut[0x266] = 0x1a;
+	*(float*)(SwitchOut + 0x2b0) =
+		*(float*)(SwitchOut + 0x2b8) =
+		*(float*)(SwitchOut + 0x2c0) = 0;
+	*(float*)(SwitchOut + 0x2c8) =
+		*(float*)(SwitchOut + 0x2d0) =
+		*(float*)(SwitchOut + 0x2d8) = 1;
+	*(float*)(SwitchOut + 0x2e0) =
+		*(float*)(SwitchOut + 0x2e8) =
+		*(float*)(SwitchOut + 0x2f0) =
+		*(float*)(SwitchOut + 0x2f8) =
+		*(float*)(SwitchOut + 0x300) =
+		*(float*)(SwitchOut + 0x308) = 0;
+	*(PDWORD)(SwitchOut + 0x388) = 0xcf8b178b;
+
+	returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+}
+
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
@@ -768,7 +672,7 @@ EXPORT PLUGIN_INFO* Get_PluginInfo()
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&CharacterSelect_AFTER, PLUGIN_HkIServerImpl_CharacterSelect_AFTER, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&ShipDestroyed, PLUGIN_ShipDestroyed, 0));
 
-	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkTimerCheckKick, PLUGIN_HkTimerCheckKick, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&SystemSwitchOutComplete, PLUGIN_HkIServerImpl_SystemSwitchOutComplete, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&UserCmd_Process, PLUGIN_UserCmd_Process, 3));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&Dock_Call, PLUGIN_HkCb_Dock_Call, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&BaseEnter, PLUGIN_HkIServerImpl_BaseEnter, 0));

--- a/Plugins/Public/mobiledocking_plugin/Main.cpp
+++ b/Plugins/Public/mobiledocking_plugin/Main.cpp
@@ -173,9 +173,6 @@ void __stdcall PlayerLaunch(unsigned int iShip, unsigned int client)
 
 		returncode = SKIPPLUGINS;
 
-		// Set last base to last real base this ship was on. POB support will be added in 0.9.X version.
-		Players[client].iLastBaseID = mobiledockClients[client].iLastBaseID;
-
 		// Check if carrier jettisons this ship.
 		if (mobiledockClients[client].forceUndocking)
 		{

--- a/Plugins/Public/mobiledocking_plugin/Main.h
+++ b/Plugins/Public/mobiledocking_plugin/Main.h
@@ -40,18 +40,16 @@ struct CLIENT_DATA
 	// A flag denoting that the above base should be used as an undock point
 	bool baseUndock = false;
 
-	// This shows you if the character is on died carrier right now.
-	bool carrierDied = false;
+	// This shows you if the character is being kicked from carrier by force.
+	bool forceUndocking = false;
 };
 
-struct ActionJettison
+struct DEFERREDJUMPS
 {
-	int timeLeft;
-	wstring carrierCharname;
-	wstring dockedCharname;
+	uint system;
+	Vector pos;
+	Matrix ornt;
 };
-
-extern vector<ActionJettison> jettisonList;
 
 void SendResetMarketOverride(uint client);
 void SendSetBaseInfoText2(UINT client, const wstring &message);

--- a/Plugins/Public/mobiledocking_plugin/Main.h
+++ b/Plugins/Public/mobiledocking_plugin/Main.h
@@ -36,20 +36,22 @@ struct CLIENT_DATA
 
 	// A base pointer used to teleport the ship into a base on undock
 	Universe::IBase *undockBase;
-	
+
 	// A flag denoting that the above base should be used as an undock point
 	bool baseUndock = false;
 
-	// This shows you if the character is being kicked from carrier by force.
-	bool forceUndocking = false;
+	// This shows you if the character is on died carrier right now.
+	bool carrierDied = false;
 };
 
-struct DEFERREDJUMPS
+struct ActionJettison
 {
-	uint system;
-	Vector pos;
-	Matrix ornt;
+	int timeLeft;
+	wstring carrierCharname;
+	wstring dockedCharname;
 };
+
+extern vector<ActionJettison> jettisonList;
 
 void SendResetMarketOverride(uint client);
 void SendSetBaseInfoText2(UINT client, const wstring &message);

--- a/Plugins/Public/mobiledocking_plugin/Main.h
+++ b/Plugins/Public/mobiledocking_plugin/Main.h
@@ -36,7 +36,7 @@ struct CLIENT_DATA
 
 	// A base pointer used to teleport the ship into a base on undock
 	Universe::IBase *undockBase;
-
+	
 	// A flag denoting that the above base should be used as an undock point
 	bool baseUndock = false;
 


### PR DESCRIPTION
Main changes:
1) Now players won't be redirected to last real base they were on if they died after being docked to carrier. This part of code suspected to be responsible for character-erasing bug.
2) Conn exploit check removed, jumps to conn were restricted long time ago, so I think it's fine.