### PR TITLE
mobiledock: Fixes

### DIFF
--- a/Plugins/Public/mobiledocking_plugin/Main.cpp
+++ b/Plugins/Public/mobiledocking_plugin/Main.cpp
@@ -44,7 +44,7 @@ void HkTimerCheckKick()
 					HkKickReason(ARG_CLIENTID(checkDockedClientID), L"Forced undocking.");
 
 					// If carrier died, we don't need this message.
-					if(!mobiledockClients[checkDockedClientID].carrierDied)
+					if (!mobiledockClients[checkDockedClientID].carrierDied)
 						PrintUserCmdText(checkCarrierClientID, L"Jettisoning ship...");
 				}
 			}
@@ -118,7 +118,7 @@ void UpdateCarrierLocationInformation(uint dockedClientId, uint carrierShip)
 	Vector& carrierPos = mobiledockClients[dockedClientId].carrierPos;
 	Matrix& carrierRot = mobiledockClients[dockedClientId].carrierRot;
 
-		
+
 	// If the carrier is out in space, simply set the undock location to where the carrier is currently
 	pub::SpaceObj::GetSystem(carrierShip, mobiledockClients[dockedClientId].carrierSystem);
 	pub::SpaceObj::GetLocation(carrierShip, carrierPos, carrierRot);
@@ -172,23 +172,23 @@ void LoadSettings()
 	char szCurDir[MAX_PATH];
 	GetCurrentDirectory(sizeof(szCurDir), szCurDir);
 	string scPluginCfgFile = string(szCurDir) + "\\flhook_plugins\\dockingmodules.cfg";
-	
+
 	int dockingModAmount = 0;
 	INI_Reader ini;
-	if(ini.open(scPluginCfgFile.c_str(), false))
+	if (ini.open(scPluginCfgFile.c_str(), false))
 	{
-		while(ini.read_header())
+		while (ini.read_header())
 		{
-			if(ini.is_header("Config"))
+			if (ini.is_header("Config"))
 			{
-				while(ini.read_value())
+				while (ini.read_value())
 				{
-					if(ini.is_value("allowedmodule"))
+					if (ini.is_value("allowedmodule"))
 					{
 						dockingModuleEquipmentIds.push_back(CreateID(ini.get_value_string()));
 						dockingModAmount++;
 					}
-					else if(ini.is_value("cargo_capacity_limit"))
+					else if (ini.is_value("cargo_capacity_limit"))
 					{
 						cargoCapacityLimit = ini.get_value_int(0);
 					}
@@ -212,7 +212,7 @@ void __stdcall BaseExit(uint iBaseID, uint iClientID)
 	mobiledockClients[iClientID].iDockingModulesAvailable = (mobiledockClients[iClientID].iDockingModulesInstalled - mobiledockClients[iClientID].mapDockedShips.size());
 
 	// If this is a ship which is currently docked, clear the market
-	if(mobiledockClients[iClientID].mobileDocked)
+	if (mobiledockClients[iClientID].mobileDocked)
 	{
 		SendResetMarketOverride(iClientID);
 	}
@@ -235,6 +235,9 @@ void __stdcall PlayerLaunch(unsigned int iShip, unsigned int client)
 	{
 
 		returncode = SKIPPLUGINS;
+
+		// Set last base to last real base this ship was on. POB support will be added in 0.9.X version.
+		Players[client].iLastBaseID = mobiledockClients[client].iLastBaseID;
 
 		// Check if carrier died.
 		if (mobiledockClients[client].carrierDied)
@@ -272,7 +275,7 @@ void __stdcall PlayerLaunch(unsigned int iShip, unsigned int client)
 			return;
 
 		}
-		
+
 		//Get the carrier ship information
 		uint carrierShip;
 		pub::Player::GetShip(carrier_client, carrierShip);
@@ -281,13 +284,13 @@ void __stdcall PlayerLaunch(unsigned int iShip, unsigned int client)
 		pub::Player::GetShip(client, clientShip);
 
 		// Check to see if the carrier is currently in a base. If so, force the client to dock on that base.
-		if(!carrierShip)
+		if (!carrierShip)
 		{
 
 			uint iBaseID;
 			pub::Player::GetBase(carrier_client, iBaseID);
 
-			if(iBaseID)
+			if (iBaseID)
 			{
 				// Set the flags which the PlayerLaunch_AFTER uses to handle teleporting to the carriers base
 				mobiledockClients[client].undockBase = Universe::get_base(iBaseID);
@@ -342,7 +345,7 @@ void __stdcall PlayerLaunch_AFTER(unsigned int ship, unsigned int client)
 	returncode = DEFAULT_RETURNCODE;
 
 	// Is the client flagged to dock at a base after exiting?
-	if(mobiledockClients[client].baseUndock)
+	if (mobiledockClients[client].baseUndock)
 	{
 		pub::Player::ForceLand(client, mobiledockClients[client].undockBase->iBaseID);
 		mobiledockClients.erase(client);
@@ -362,9 +365,23 @@ void __stdcall PlayerLaunch_AFTER(unsigned int ship, unsigned int client)
 		}
 
 		pub::Player::ForceLand(client, mobiledockClients[client].proxyBaseID);
+
 		// Send the message because if carrier goes to another system, docked ships remain in previous with outdated system navmap. We notify client about it is being updated.
 		PrintUserCmdText(client, L"Navmap updated successfully.");
-		mobiledockClients[client].carrierSystem = Players[client].iSystemID;
+
+		// Update current system stat in player list to be displayed relevantly.
+		Server.BaseEnter(mobiledockClients[client].proxyBaseID, client);
+		Server.BaseExit(mobiledockClients[client].proxyBaseID, client);
+		wstring wscCharFileName;
+		HkGetCharFileName((const wchar_t*)Players.GetActiveCharacterName(client), wscCharFileName);
+		wscCharFileName += L".fl";
+		CHARACTER_ID cID;
+		strcpy(cID.szCharFilename, wstos(wscCharFileName.substr(0, 14)).c_str());
+		Server.CharacterSelect(cID, client);
+
+		// Update current system stat in plugin data.
+		Universe::IBase* base = Universe::get_base(mobiledockClients[client].proxyBaseID);
+		mobiledockClients[client].carrierSystem = base->iSystemID;
 	}
 }
 
@@ -483,36 +500,36 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 {
 	returncode = DEFAULT_RETURNCODE;
 
-	if(wscCmd.find(L"/listdocked") == 0)
+	if (wscCmd.find(L"/listdocked") == 0)
 	{
-		if(mobiledockClients[client].mapDockedShips.empty())
+		if (mobiledockClients[client].mapDockedShips.empty())
 		{
 			PrintUserCmdText(client, L"No ships currently docked");
 		}
 		else
 		{
 			PrintUserCmdText(client, L"Docked ships:");
-			for(map<wstring, wstring>::iterator i = mobiledockClients[client].mapDockedShips.begin();
+			for (map<wstring, wstring>::iterator i = mobiledockClients[client].mapDockedShips.begin();
 				i != mobiledockClients[client].mapDockedShips.end(); ++i)
 			{
 				PrintUserCmdText(client, i->first);
 			}
 		}
 	}
-	else if(wscCmd.find(L"/conn") == 0)
+	else if (wscCmd.find(L"/conn") == 0)
 	{
 		// This plugin always runs before the Conn Plugin runs it's /conn function. Verify that there are no docked ships.
-		if(!mobiledockClients[client].mapDockedShips.empty())
+		if (!mobiledockClients[client].mapDockedShips.empty())
 		{
 			PrintUserCmdText(client, L"You cannot use this command if you have vessels docked with you!");
 			returncode = SKIPPLUGINS;
 		}
 	}
-	else if(wscCmd.find(L"/jettisonship") == 0)
+	else if (wscCmd.find(L"/jettisonship") == 0)
 	{
 		// Get the supposed ship we should be ejecting from the command parameters
 		wstring charname = Trim(GetParam(wscCmd, ' ', 1));
-		if(charname.empty())
+		if (charname.empty())
 		{
 			PrintUserCmdText(client, L"Usage: /jettisonship <charname>");
 			return true;
@@ -521,7 +538,7 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 		// Only allow jettisonning a ship if the carrier is undocked
 		uint carrierShip;
 		pub::Player::GetShip(client, carrierShip);
-		if(!carrierShip)
+		if (!carrierShip)
 		{
 			PrintUserCmdText(client, L"You can only jettison a vessel if you are in space.");
 			return true;
@@ -529,7 +546,7 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 
 
 		// Check to see if the user listed is actually docked with the carrier at the moment
-		if(mobiledockClients[client].mapDockedShips.find(charname) == mobiledockClients[client].mapDockedShips.end())
+		if (mobiledockClients[client].mapDockedShips.find(charname) == mobiledockClients[client].mapDockedShips.end())
 		{
 			PrintUserCmdText(client, L"%s is not docked with you!", charname);
 			return true;
@@ -537,7 +554,7 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 
 		// The player exists. Remove him from the docked list, and kick him into space
 		const uint iDockedClientID = HkGetClientIdFromCharname(charname);
-		if(iDockedClientID)
+		if (iDockedClientID)
 		{
 			// Update the client with the current carrier location
 			UpdateCarrierLocationInformation(iDockedClientID, carrierShip);
@@ -549,7 +566,7 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 		return true;
 
 	}
-	else if(wscCmd.find(L"/allowdock")==0)
+	else if (wscCmd.find(L"/allowdock") == 0)
 	{
 		//If we're not in space, then ignore the request
 		uint iShip;
@@ -589,7 +606,7 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 		// Check if we're in conn. If so, reject the request
 		uint clientSystem;
 		pub::SpaceObj::GetSystem(client, clientSystem);
-		if(clientSystem == connSystemID)
+		if (clientSystem == connSystemID)
 		{
 			mapPendingDockingRequests.erase(iTargetClientID);
 			PrintUserCmdText(client, L"You cannot dock in Connecticut.");
@@ -601,7 +618,7 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 
 		string scProxyBase = HkGetPlayerSystemS(client) + "_proxy_base";
 		uint iBaseID;
-		if(pub::GetBaseID(iBaseID, scProxyBase.c_str()) == -4)
+		if (pub::GetBaseID(iBaseID, scProxyBase.c_str()) == -4)
 		{
 			PrintUserCmdText(client, L"No proxy base in system detected. Contact a developer about this please. Required base: %s", scProxyBase);
 			return true;
@@ -669,7 +686,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 	// calls load settings on FLHook startup and .rehash.
 	if (fdwReason == DLL_PROCESS_ATTACH)
 	{
-		if (set_scCfgFile.length()>0)
+		if (set_scCfgFile.length() > 0)
 			LoadSettings();
 	}
 	else if (fdwReason == DLL_PROCESS_DETACH)

--- a/Plugins/Public/mobiledocking_plugin/Main.cpp
+++ b/Plugins/Public/mobiledocking_plugin/Main.cpp
@@ -116,7 +116,7 @@ void UpdateCarrierLocationInformation(uint dockedClientId, uint carrierShip)
 	Vector& carrierPos = mobiledockClients[dockedClientId].carrierPos;
 	Matrix& carrierRot = mobiledockClients[dockedClientId].carrierRot;
 
-			
+		
 	// If the carrier is out in space, simply set the undock location to where the carrier is currently
 	pub::SpaceObj::GetSystem(carrierShip, mobiledockClients[dockedClientId].carrierSystem);
 	pub::SpaceObj::GetLocation(carrierShip, carrierPos, carrierRot);
@@ -170,7 +170,7 @@ void LoadSettings()
 	char szCurDir[MAX_PATH];
 	GetCurrentDirectory(sizeof(szCurDir), szCurDir);
 	string scPluginCfgFile = string(szCurDir) + "\\flhook_plugins\\dockingmodules.cfg";
-		
+	
 	int dockingModAmount = 0;
 	INI_Reader ini;
 	if(ini.open(scPluginCfgFile.c_str(), false))
@@ -273,7 +273,7 @@ void __stdcall PlayerLaunch(unsigned int iShip, unsigned int client)
 			return;
 
 		}
-				
+		
 		//Get the carrier ship information
 		uint carrierShip;
 		pub::Player::GetShip(carrier_client, carrierShip);

--- a/Plugins/Public/mobiledocking_plugin/Main.cpp
+++ b/Plugins/Public/mobiledocking_plugin/Main.cpp
@@ -18,8 +18,6 @@ int cargoCapacityLimit = 275;
 // How much time will player be given before kick if carrier wants to jettison him.
 int jettisonKickTime = 15;
 
-uint connSystemID = CreateID("li06");
-
 // Delayed actions, which need to be done. Look at HkTimerCheckKick().
 vector<ActionJettison> jettisonList;
 
@@ -44,7 +42,7 @@ void HkTimerCheckKick()
 					HkKickReason(ARG_CLIENTID(checkDockedClientID), L"Forced undocking.");
 
 					// If carrier died, we don't need this message.
-					if (!mobiledockClients[checkDockedClientID].carrierDied)
+					if(!mobiledockClients[checkDockedClientID].carrierDied)
 						PrintUserCmdText(checkCarrierClientID, L"Jettisoning ship...");
 				}
 			}
@@ -118,7 +116,7 @@ void UpdateCarrierLocationInformation(uint dockedClientId, uint carrierShip)
 	Vector& carrierPos = mobiledockClients[dockedClientId].carrierPos;
 	Matrix& carrierRot = mobiledockClients[dockedClientId].carrierRot;
 
-
+			
 	// If the carrier is out in space, simply set the undock location to where the carrier is currently
 	pub::SpaceObj::GetSystem(carrierShip, mobiledockClients[dockedClientId].carrierSystem);
 	pub::SpaceObj::GetLocation(carrierShip, carrierPos, carrierRot);
@@ -172,23 +170,23 @@ void LoadSettings()
 	char szCurDir[MAX_PATH];
 	GetCurrentDirectory(sizeof(szCurDir), szCurDir);
 	string scPluginCfgFile = string(szCurDir) + "\\flhook_plugins\\dockingmodules.cfg";
-
+		
 	int dockingModAmount = 0;
 	INI_Reader ini;
-	if (ini.open(scPluginCfgFile.c_str(), false))
+	if(ini.open(scPluginCfgFile.c_str(), false))
 	{
-		while (ini.read_header())
+		while(ini.read_header())
 		{
-			if (ini.is_header("Config"))
+			if(ini.is_header("Config"))
 			{
-				while (ini.read_value())
+				while(ini.read_value())
 				{
-					if (ini.is_value("allowedmodule"))
+					if(ini.is_value("allowedmodule"))
 					{
 						dockingModuleEquipmentIds.push_back(CreateID(ini.get_value_string()));
 						dockingModAmount++;
 					}
-					else if (ini.is_value("cargo_capacity_limit"))
+					else if(ini.is_value("cargo_capacity_limit"))
 					{
 						cargoCapacityLimit = ini.get_value_int(0);
 					}
@@ -212,7 +210,7 @@ void __stdcall BaseExit(uint iBaseID, uint iClientID)
 	mobiledockClients[iClientID].iDockingModulesAvailable = (mobiledockClients[iClientID].iDockingModulesInstalled - mobiledockClients[iClientID].mapDockedShips.size());
 
 	// If this is a ship which is currently docked, clear the market
-	if (mobiledockClients[iClientID].mobileDocked)
+	if(mobiledockClients[iClientID].mobileDocked)
 	{
 		SendResetMarketOverride(iClientID);
 	}
@@ -275,7 +273,7 @@ void __stdcall PlayerLaunch(unsigned int iShip, unsigned int client)
 			return;
 
 		}
-
+				
 		//Get the carrier ship information
 		uint carrierShip;
 		pub::Player::GetShip(carrier_client, carrierShip);
@@ -284,13 +282,13 @@ void __stdcall PlayerLaunch(unsigned int iShip, unsigned int client)
 		pub::Player::GetShip(client, clientShip);
 
 		// Check to see if the carrier is currently in a base. If so, force the client to dock on that base.
-		if (!carrierShip)
+		if(!carrierShip)
 		{
 
 			uint iBaseID;
 			pub::Player::GetBase(carrier_client, iBaseID);
 
-			if (iBaseID)
+			if(iBaseID)
 			{
 				// Set the flags which the PlayerLaunch_AFTER uses to handle teleporting to the carriers base
 				mobiledockClients[client].undockBase = Universe::get_base(iBaseID);
@@ -345,7 +343,7 @@ void __stdcall PlayerLaunch_AFTER(unsigned int ship, unsigned int client)
 	returncode = DEFAULT_RETURNCODE;
 
 	// Is the client flagged to dock at a base after exiting?
-	if (mobiledockClients[client].baseUndock)
+	if(mobiledockClients[client].baseUndock)
 	{
 		pub::Player::ForceLand(client, mobiledockClients[client].undockBase->iBaseID);
 		mobiledockClients.erase(client);
@@ -500,36 +498,36 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 {
 	returncode = DEFAULT_RETURNCODE;
 
-	if (wscCmd.find(L"/listdocked") == 0)
+	if(wscCmd.find(L"/listdocked") == 0)
 	{
-		if (mobiledockClients[client].mapDockedShips.empty())
+		if(mobiledockClients[client].mapDockedShips.empty())
 		{
 			PrintUserCmdText(client, L"No ships currently docked");
 		}
 		else
 		{
 			PrintUserCmdText(client, L"Docked ships:");
-			for (map<wstring, wstring>::iterator i = mobiledockClients[client].mapDockedShips.begin();
+			for(map<wstring, wstring>::iterator i = mobiledockClients[client].mapDockedShips.begin();
 				i != mobiledockClients[client].mapDockedShips.end(); ++i)
 			{
 				PrintUserCmdText(client, i->first);
 			}
 		}
 	}
-	else if (wscCmd.find(L"/conn") == 0)
+	else if(wscCmd.find(L"/conn") == 0)
 	{
 		// This plugin always runs before the Conn Plugin runs it's /conn function. Verify that there are no docked ships.
-		if (!mobiledockClients[client].mapDockedShips.empty())
+		if(!mobiledockClients[client].mapDockedShips.empty())
 		{
 			PrintUserCmdText(client, L"You cannot use this command if you have vessels docked with you!");
 			returncode = SKIPPLUGINS;
 		}
 	}
-	else if (wscCmd.find(L"/jettisonship") == 0)
+	else if(wscCmd.find(L"/jettisonship") == 0)
 	{
 		// Get the supposed ship we should be ejecting from the command parameters
 		wstring charname = Trim(GetParam(wscCmd, ' ', 1));
-		if (charname.empty())
+		if(charname.empty())
 		{
 			PrintUserCmdText(client, L"Usage: /jettisonship <charname>");
 			return true;
@@ -538,7 +536,7 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 		// Only allow jettisonning a ship if the carrier is undocked
 		uint carrierShip;
 		pub::Player::GetShip(client, carrierShip);
-		if (!carrierShip)
+		if(!carrierShip)
 		{
 			PrintUserCmdText(client, L"You can only jettison a vessel if you are in space.");
 			return true;
@@ -546,7 +544,7 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 
 
 		// Check to see if the user listed is actually docked with the carrier at the moment
-		if (mobiledockClients[client].mapDockedShips.find(charname) == mobiledockClients[client].mapDockedShips.end())
+		if(mobiledockClients[client].mapDockedShips.find(charname) == mobiledockClients[client].mapDockedShips.end())
 		{
 			PrintUserCmdText(client, L"%s is not docked with you!", charname);
 			return true;
@@ -554,7 +552,7 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 
 		// The player exists. Remove him from the docked list, and kick him into space
 		const uint iDockedClientID = HkGetClientIdFromCharname(charname);
-		if (iDockedClientID)
+		if(iDockedClientID)
 		{
 			// Update the client with the current carrier location
 			UpdateCarrierLocationInformation(iDockedClientID, carrierShip);
@@ -566,7 +564,7 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 		return true;
 
 	}
-	else if (wscCmd.find(L"/allowdock") == 0)
+	else if(wscCmd.find(L"/allowdock")==0)
 	{
 		//If we're not in space, then ignore the request
 		uint iShip;
@@ -603,22 +601,12 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 			return true;
 		}
 
-		// Check if we're in conn. If so, reject the request
-		uint clientSystem;
-		pub::SpaceObj::GetSystem(client, clientSystem);
-		if (clientSystem == connSystemID)
-		{
-			mapPendingDockingRequests.erase(iTargetClientID);
-			PrintUserCmdText(client, L"You cannot dock in Connecticut.");
-			return true;
-		}
-
 		// The client is free to dock, erase from the pending list and handle
 		mapPendingDockingRequests.erase(iTargetClientID);
 
 		string scProxyBase = HkGetPlayerSystemS(client) + "_proxy_base";
 		uint iBaseID;
-		if (pub::GetBaseID(iBaseID, scProxyBase.c_str()) == -4)
+		if(pub::GetBaseID(iBaseID, scProxyBase.c_str()) == -4)
 		{
 			PrintUserCmdText(client, L"No proxy base in system detected. Contact a developer about this please. Required base: %s", scProxyBase);
 			return true;
@@ -686,7 +674,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 	// calls load settings on FLHook startup and .rehash.
 	if (fdwReason == DLL_PROCESS_ATTACH)
 	{
-		if (set_scCfgFile.length() > 0)
+		if (set_scCfgFile.length()>0)
 			LoadSettings();
 	}
 	else if (fdwReason == DLL_PROCESS_DETACH)

--- a/Plugins/Public/mobiledocking_plugin/Main.cpp
+++ b/Plugins/Public/mobiledocking_plugin/Main.cpp
@@ -514,7 +514,7 @@ bool UserCmd_Process(uint client, const wstring &wscCmd)
 			}
 		}
 	}
-	else if(wscCmd.find(L"/conn") == 0)
+	else if(wscCmd.find(L"/conn") == 0 || wscCmd.find(L"/return") == 0)
 	{
 		// This plugin always runs before the Conn Plugin runs it's /conn function. Verify that there are no docked ships.
 		if(!mobiledockClients[client].mapDockedShips.empty())


### PR DESCRIPTION
Main changes:
1) Redirecting players to last real base is returned, because doesn't cause character-erasing bug.
2) Now when redirecting to proxy base in another system, plugin updates current system value in player list.
3) More irrelevant Connecticut checks removed. This one supposed to restrict docking in conn, but didn't work anyway. I replaced it with new one: none able to /return from conn with docked ships on board.