### PR TITLE
Revert "npc_control: Advanced NPC disabling"

### DIFF
--- a/Binaries/bin-conf/flhook_plugins/alley_npc.cfg
+++ b/Binaries/bin-conf/flhook_plugins/alley_npc.cfg
@@ -145,10 +145,3 @@ fleetmember = nomlnvhf, 8
 [fleet]
 fleetname = nomvhfs
 fleetmember = nomvhf, 6
-
-[disable]
-ServerLoad_DisableSpawn = 0
-Exception_ShipArch = dsy_dynamic_anomaly01
-Exception_ShipArch = dsy_dynamic_anomaly02
-Exception_ShipArch = dsy_dynamic_anomaly03
-Exception_System = St03


### PR DESCRIPTION
Reverts DiscoveryGC/FLHook#98

We ran into loads of problems with this, there seems to be all sorts of hidden compatibility and memory usage issues associated with it.