### PR TITLE
npc-control: Added optional parameter to .aifollow to specify which character to follow

### DIFF
--- a/Plugins/Public/npc_control/Main.cpp
+++ b/Plugins/Public/npc_control/Main.cpp
@@ -631,7 +631,7 @@ void AdminCmd_AICome(CCmds* cmds)
 }
 
 /* Make AI follow you until death */
-void AdminCmd_AIFollow(CCmds* cmds)
+void AdminCmd_AIFollow(CCmds* cmds, wstring Charname)
 {
 	if (!(cmds->rights & RIGHT_SUPERADMIN))
 	{
@@ -639,22 +639,39 @@ void AdminCmd_AIFollow(CCmds* cmds)
 		return;
 	}
 
-	uint iShip1;
-	pub::Player::GetShip(HkGetClientIdFromCharname(cmds->GetAdminName()), iShip1);
-	if (iShip1)
-	{
-		foreach(npcs, uint, iShipIter)
+	// If no player specified follow the admin
+	uint iClientId;
+	if (Charname == L"") {
+		iClientId = HkGetClientIdFromCharname(cmds->GetAdminName());
+		Charname = cmds->GetAdminName();
+	}
+	// Follow the player specified
+	else {
+		iClientId = HkGetClientIdFromCharname(Charname);
+	}
+	if (iClientId == -1) {
+		cmds->Print(L"%s is not online\n", Charname.c_str());
+	}
+	else {
+		uint iShip1;
+		pub::Player::GetShip(iClientId, iShip1);
+		if (iShip1)
 		{
-			pub::AI::DirectiveCancelOp cancelOP;
-			pub::AI::SubmitDirective(*iShipIter, &cancelOP);
-
-			pub::AI::DirectiveFollowOp testOP;
-			testOP.leader = iShip1;
-			testOP.max_distance = 100;
-			pub::AI::SubmitDirective(*iShipIter, &testOP);
+			foreach(npcs, uint, iShipIter)
+			{
+				pub::AI::DirectiveCancelOp cancelOP;
+				pub::AI::SubmitDirective(*iShipIter, &cancelOP);
+				pub::AI::DirectiveFollowOp testOP;
+				testOP.leader = iShip1;
+				testOP.max_distance = 100;
+				pub::AI::SubmitDirective(*iShipIter, &testOP);
+			}
+			cmds->Print(L"Following %s\n", Charname.c_str());
+		}
+		else {
+			cmds->Print(L"%s is not in space\n", Charname.c_str());
 		}
 	}
-	cmds->Print(L"OK\n");
 	return;
 }
 
@@ -828,7 +845,7 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	else if (IS_CMD("aifollow"))
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
-		AdminCmd_AIFollow(cmds);
+		AdminCmd_AIFollow(cmds, cmds->ArgStr(1));
 		return true;
 	}
 	else if (IS_CMD("aicome"))

--- a/Plugins/Public/npc_control/Main.cpp
+++ b/Plugins/Public/npc_control/Main.cpp
@@ -631,7 +631,7 @@ void AdminCmd_AICome(CCmds* cmds)
 }
 
 /* Make AI follow you until death */
-void AdminCmd_AIFollow(CCmds* cmds, wstring Charname)
+void AdminCmd_AIFollow(CCmds* cmds, wstring &wscCharname)
 {
 	if (!(cmds->rights & RIGHT_SUPERADMIN))
 	{
@@ -641,16 +641,16 @@ void AdminCmd_AIFollow(CCmds* cmds, wstring Charname)
 
 	// If no player specified follow the admin
 	uint iClientId;
-	if (Charname == L"") {
+	if (wscCharname == L"") {
 		iClientId = HkGetClientIdFromCharname(cmds->GetAdminName());
-		Charname = cmds->GetAdminName();
+		wscCharname = cmds->GetAdminName();
 	}
 	// Follow the player specified
 	else {
-		iClientId = HkGetClientIdFromCharname(Charname);
+		iClientId = HkGetClientIdFromCharname(wscCharname);
 	}
 	if (iClientId == -1) {
-		cmds->Print(L"%s is not online\n", Charname.c_str());
+		cmds->Print(L"%s is not online\n", wscCharname.c_str());
 	}
 	else {
 		uint iShip1;
@@ -666,10 +666,10 @@ void AdminCmd_AIFollow(CCmds* cmds, wstring Charname)
 				testOP.max_distance = 100;
 				pub::AI::SubmitDirective(*iShipIter, &testOP);
 			}
-			cmds->Print(L"Following %s\n", Charname.c_str());
+			cmds->Print(L"Following %s\n", wscCharname.c_str());
 		}
 		else {
-			cmds->Print(L"%s is not in space\n", Charname.c_str());
+			cmds->Print(L"%s is not in space\n", wscCharname.c_str());
 		}
 	}
 	return;
@@ -845,7 +845,7 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	else if (IS_CMD("aifollow"))
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
-		AdminCmd_AIFollow(cmds, cmds->ArgStr(1));
+		AdminCmd_AIFollow(cmds, cmds->ArgCharname(1));
 		return true;
 	}
 	else if (IS_CMD("aicome"))


### PR DESCRIPTION
**Examples:**

_.aifollow_ (Will follow the admin and send a message to command giver saying "Following Player1".
_.aifollow player2_ (Will follow the 2nd player and send a message to command giver  saying "Following Player2".

If you try to use this on a character that is not online you get: "Player2 is not online".

If you try and use this on a character that is not in space you get: "Player2 is not in space"