### PR TITLE
npc-control: Added 2 optional infocard parameters

### DIFF
--- a/Binaries/bin-conf/flhook_plugins/alley_npc.cfg
+++ b/Binaries/bin-conf/flhook_plugins/alley_npc.cfg
@@ -67,6 +67,10 @@ npc = pf02vhf, dsy_li_elite3, li_n_vhf_elite_l2_d19, pf_02_grp, 0
 npc = piratevhf, dsy_oc_vhf, fc_ou_vhf_hard_l1_d17_d18, fc_pirate, 0
 ;end pf tests
 
+;custom infocard example
+;npc = juni, dsy_li_gunboat, Liberty_Gunboat_Loadout, li_n_grp, 2, 216400
+;npc = juni2, dsy_li_gunboat, Liberty_Gunboat_Loadout, li_n_grp, 2, 197828, 197827
+
 [fleet]
 fleetname = bretoniansnub
 fleetmember = bafvhf, 7

--- a/Plugins/Public/npc_control/Main.cpp
+++ b/Plugins/Public/npc_control/Main.cpp
@@ -73,6 +73,8 @@ struct NPC_ARCHTYPESSTRUCT
 	uint Shiparch;
 	uint Loadout;
 	uint IFF;
+	uint Infocard;
+	uint Infocard2;
 	int Graph;
 };
 
@@ -307,11 +309,15 @@ void LoadNPCInfo()
 						setnpcstruct.Shiparch = CreateID(ini.get_value_string(1));
 						setnpcstruct.Loadout = CreateID(ini.get_value_string(2));
 
-						//IFF calc
+						// IFF calc
 						 pub::Reputation::GetReputationGroup(setnpcstruct.IFF, ini.get_value_string(3));
 
-						//Selected graph
+						// Selected graph
 						setnpcstruct.Graph = ini.get_value_int(4);
+
+						// Infocard
+						setnpcstruct.Infocard = ini.get_value_int(5);
+						setnpcstruct.Infocard2 = ini.get_value_int(6);
 
 						mapNPCArchtypes[thenpcname] = setnpcstruct;
 					}
@@ -503,8 +509,16 @@ void CreateNPC(wstring name, Vector pos, Matrix rot, uint iSystem)
 		// below shows the use of multiple part names.
 		FmtStr pilot_name(0, 0);
 		pilot_name.begin_mad_lib(16163); // ids of "%s0 %s1"
-		pilot_name.append_string(rand_name());  // ids that replaces %s0
-		pilot_name.append_string(rand_name()); // ids that replaces %s1
+		if (arch.Infocard != 0) {
+			pilot_name.append_string(arch.Infocard);
+			if (arch.Infocard2 != 0) {
+				pilot_name.append_string(arch.Infocard2);
+			}
+		}
+		else {
+			pilot_name.append_string(rand_name());  // ids that replaces %s0
+			pilot_name.append_string(rand_name()); // ids that replaces %s1
+		}
 		pilot_name.end_mad_lib();
 
 		pub::Reputation::Alloc(si.iRep, scanner_name, pilot_name);

--- a/Plugins/Public/npc_control/Main.cpp
+++ b/Plugins/Public/npc_control/Main.cpp
@@ -316,6 +316,8 @@ void LoadNPCInfo()
 						setnpcstruct.Graph = ini.get_value_int(4);
 
 						// Infocard
+						setnpcstruct.Infocard = 0;
+						setnpcstruct.Infocard2 = 0;
 						setnpcstruct.Infocard = ini.get_value_int(5);
 						setnpcstruct.Infocard2 = ini.get_value_int(6);
 

--- a/Plugins/Public/npc_control/Main.cpp
+++ b/Plugins/Public/npc_control/Main.cpp
@@ -316,8 +316,6 @@ void LoadNPCInfo()
 						setnpcstruct.Graph = ini.get_value_int(4);
 
 						// Infocard
-						setnpcstruct.Infocard = 0;
-						setnpcstruct.Infocard2 = 0;
 						setnpcstruct.Infocard = ini.get_value_int(5);
 						setnpcstruct.Infocard2 = ini.get_value_int(6);
 


### PR DESCRIPTION
Added 2 optional infocard parameters to npc in alley_npc.cfg. Either one or two infocard parameters may be used. If none are specified it will generate random names as per previous functionality.