### PR TITLE
HyperJump (1/7)

### DIFF
--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -36,7 +36,7 @@ namespace HyperJump
 			ConPrint(L"ERROR: item '%s' is not valid\n", stows(nickname).c_str());
 		}
 
-		return item;
+		return item;	
 	}
 
 	// Ships restricted from jumping
@@ -171,9 +171,9 @@ namespace HyperJump
 	{
 		wstring sbuf;
 		wchar_t buf[100];
-		for (int i = 0; i < HCOORD_SIZE; i++)
+		for (int i=0; i<HCOORD_SIZE; i++)
 		{
-			if (i != 0 && (i % 4) == 0) sbuf += L"-";
+			if (i!=0 && (i%4)==0) sbuf += L"-";
 			_snwprintf(buf, sizeof(buf), L"%02X", (byte)ibuf[i]);
 			sbuf += buf;
 		}
@@ -184,7 +184,7 @@ namespace HyperJump
 	{
 		obuf[0] = ibuf[0];
 		obuf[1] = ibuf[1];
-		for (uint i = 2, p = ibuf[0] % set_scEncryptKey.length(); i < HCOORD_SIZE; i++, p++)
+		for (uint i=2, p=ibuf[0]%set_scEncryptKey.length(); i<HCOORD_SIZE; i++, p++)
 		{
 			if (p > set_scEncryptKey.length())
 				p = 0;
@@ -221,7 +221,7 @@ namespace HyperJump
 		GetCurrentDirectory(sizeof(szCurDir), szCurDir);
 		string scCfgFile = string(szCurDir) + "\\flhook_plugins\\jump.cfg";
 		string scCfgFileSystemList = string(szCurDir) + "\\flhook_plugins\\jump_allowedsystems.cfg";
-
+			
 		int iItemID = 1;
 
 		INI_Reader ini;
@@ -264,7 +264,7 @@ namespace HyperJump
 						{
 							BeaconCooldown = ini.get_value_int(0);
 						}
-					}
+					}				
 				}
 				else if (ini.is_header("shiprestrictions"))
 				{
@@ -285,7 +285,7 @@ namespace HyperJump
 					while (ini.read_value())
 					{
 						if (ini.is_value("nickname"))
-						{
+						{ 
 							jd.nickname = CreateValidID(ini.get_value_string(0));
 						}
 						else if (ini.is_value("can_jump_charge"))
@@ -335,7 +335,7 @@ namespace HyperJump
 					while (ini.read_value())
 					{
 						if (ini.is_value("nickname"))
-						{
+						{ 
 							hs.nickname = CreateValidID(ini.get_value_string(0));
 						}
 						else if (ini.is_value("survey_complete_charge"))
@@ -384,7 +384,6 @@ namespace HyperJump
 					}
 					mapBeaconMatrix[bm.nickname] = bm;
 				}
-
 			}
 			if (BeaconCommodity == 0)
 			{
@@ -408,7 +407,7 @@ namespace HyperJump
 					while (ini.read_value())
 					{
 						if (ini.is_value("nickname"))
-						{
+						{ 
 							nickname = CreateID(ini.get_value_string(0));
 						}
 						else if (ini.is_value("jump"))
@@ -471,11 +470,11 @@ namespace HyperJump
 		IObjInspectImpl *obj = HkGetInspect(iClientID);
 		if (obj)
 		{
-			foreach(mapJumpDrives[iClientID].active_charge_fuse, uint, fuse)
-				HkUnLightFuse((IObjRW*)obj, *fuse, 0);
+			foreach (mapJumpDrives[iClientID].active_charge_fuse, uint, fuse)
+				HkUnLightFuse((IObjRW*) obj, *fuse, 0);
 			mapJumpDrives[iClientID].active_charge_fuse.clear();
 		}
-	}
+	}			
 
 	bool HyperJump::UserCmd_ListJumpableSystems(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
 	{
@@ -485,18 +484,18 @@ namespace HyperJump
 		wstring wscSysName = HkGetWStringFromIDS(iSys->strid_name);
 
 		PrintUserCmdText(iClientID, L"Space kitteh knows you are in %s !", wscSysName.c_str());
-
+				
 		if (JumpWhiteListEnabled == 1)
 		{
-			for (map<uint, SYSTEM_JUMPLIST>::iterator iter = mapJumpSystems.begin(); iter != mapJumpSystems.end(); iter++)
+			for (map<uint, SYSTEM_JUMPLIST>::iterator iter = mapJumpSystems.begin(); iter!=mapJumpSystems.end(); iter++)
 			{
-				SYSTEM_JUMPLIST &jumpsyslist = iter->second;
+				vector<uint> &systemList = iter->second.visibleSystemsList;
 				if (iter->first == iSystemID)
 				{
 					PrintUserCmdText(iClientID, L"The script has found %s !", wscSysName.c_str());
 					PrintUserCmdText(iClientID, L"You are allowed to jump to:");
 
-					for (auto &allowed_sys : jumpsyslist.visibleSystemsList)
+					for (uint &allowed_sys : systemList)
 					{
 						const Universe::ISystem *iSysList = Universe::get_system(allowed_sys);
 						wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
@@ -507,7 +506,7 @@ namespace HyperJump
 		}
 		else
 		{
-			PrintUserCmdText(iClientID, L"Jump System Whitelisting is not enabled.");
+			PrintUserCmdText(iClientID, L"Jump System Whitelisting is not enabled.");	
 		}
 		return true;
 	}
@@ -519,7 +518,7 @@ namespace HyperJump
 		if (allowedSystemIter == mapJumpSystems.end())
 			return false;
 
-		auto &allowedSystems = allowedSystemIter->second.visibleSystemsList;
+		vector<uint> &allowedSystems = allowedSystemIter->second.visibleSystemsList;
 		return find(allowedSystems.begin(), allowedSystems.end(), systemTo) != allowedSystems.end();
 	}
 
@@ -552,7 +551,7 @@ namespace HyperJump
 		}
 
 		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
+		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false)!=HKE_OK || adminPlyr.iShip==0)
 		{
 			cmds->Print(L"ERR Not in space\n");
 			return;
@@ -576,7 +575,7 @@ namespace HyperJump
 
 		// Calculate a simple parity check
 		WORD parity = 0;
-		for (int i = 2; i < HCOORD_SIZE; i++)
+		for (int i=2; i<HCOORD_SIZE; i++)
 			parity += ibuf[i];
 		coords.parity = parity;
 
@@ -596,7 +595,7 @@ namespace HyperJump
 
 		// Handle beacons
 
-		for (map<uint, BEACONTIMER>::iterator i = mapActiveBeacons.begin(); i != mapActiveBeacons.end(); ++i)
+		for (map<uint, BEACONTIMER>::iterator i = mapActiveBeacons.begin(); i != mapActiveBeacons.end(); ++i) 
 		{
 			BEACONTIMER &bc = i->second;
 
@@ -627,13 +626,13 @@ namespace HyperJump
 		}
 
 		// Handle survey charging
-		for (map<uint, SURVEY>::iterator iter = mapSurvey.begin(); iter != mapSurvey.end(); iter++)
+		for (map<uint, SURVEY>::iterator iter = mapSurvey.begin(); iter!=mapSurvey.end(); iter++)
 		{
 			uint iClientID = iter->first;
-
+						
 			uint iShip;
 			pub::Player::GetShip(iClientID, iShip);
-			if (iShip == 0)
+			if (iShip==0)
 			{
 				lstOldClients.push_back(iClientID);
 			}
@@ -663,7 +662,7 @@ namespace HyperJump
 					Vector dir1;
 					Vector dir2;
 					pub::SpaceObj::GetMotion(iShip, dir1, dir2);
-					if (dir1.x > 5 || dir1.y > 5 || dir1.z > 5)
+					if (dir1.x>5 || dir1.y>5 || dir1.z>5)
 					{
 						sm.charging_on = false;
 					}
@@ -698,27 +697,27 @@ namespace HyperJump
 
 						// Calculate a simple parity check
 						WORD parity = 0;
-						for (int i = 2; i < HCOORD_SIZE; i++)
+						for (int i=2; i<HCOORD_SIZE; i++)
 							parity += ibuf[i];
 						coords.parity = parity;
 
 						// Encrypt it
 						char obuf[HCOORD_SIZE];
 						EncryptDecrypt(ibuf, obuf);
-						PrintUserCmdText(iClientID, L"Hyperspace survey complete");	
+						PrintUserCmdText(iClientID, L"Hyperspace survey complete");
 						PrintUserCmdText(iClientID, L"Coords: %s", FormatCoords(obuf).c_str());
 
 						lstOldClients.push_back(iClientID);
 					}
 					else if (time(0) % 10 == 0)
 					{
-						PrintUserCmdText(iClientID, L"Survey %0.0f%% complete", (sm.curr_charge / sm.arch.survey_complete_charge)*100.0f);
+						PrintUserCmdText(iClientID, L"Survey %0.0f%% complete", (sm.curr_charge/sm.arch.survey_complete_charge)*100.0f);				
 					}
 				}
 			}
 		}
 
-		foreach(lstOldClients, uint, iClientID)
+		foreach (lstOldClients, uint, iClientID)
 		{
 			mapSurvey.erase(*iClientID);
 		}
@@ -726,13 +725,13 @@ namespace HyperJump
 		lstOldClients.clear();
 
 		// Handle jump drive charging
-		for (map<uint, JUMPDRIVE>::iterator iter = mapJumpDrives.begin(); iter != mapJumpDrives.end(); iter++)
+		for (map<uint, JUMPDRIVE>::iterator iter = mapJumpDrives.begin(); iter!=mapJumpDrives.end(); iter++)
 		{
 			uint iClientID = iter->first;
-
+						
 			uint iShip;
 			pub::Player::GetShip(iClientID, iShip);
-			if (iShip == 0)
+			if (iShip==0)
 			{
 				lstOldClients.push_back(iClientID);
 			}
@@ -754,7 +753,7 @@ namespace HyperJump
 					jd.jump_timer--;
 					// Turn on the jumpdrive flash
 					if (jd.jump_timer == 7)
-					{
+					{	
 						jd.charging_complete = false;
 						jd.curr_charge = 0.0;
 						jd.charging_on = false;
@@ -779,20 +778,20 @@ namespace HyperJump
 						// Restrict some ships from jumping, this is for the jumpship
 						Archetype::Ship *ship = Archetype::GetShip(Players[iClientID].iShipArchetype);
 						wstring playershiparch = stows(ship->szName);
-						if (mapRestrictedShips.find(playershiparch) != mapRestrictedShips.end() && JumpWhiteListEnabled == 1)
+						if (mapRestrictedShips.find(playershiparch) != mapRestrictedShips.end() && JumpWhiteListEnabled == 1) 
 						{
-							PrintUserCmdText(iClientID, L"ERR Ship is not allowed to jump.");
+							PrintUserCmdText(iClientID, L"ERR Ship is not allowed to jump."); 
 						}
-						else
+						else 
 						{
-							SwitchSystem(iClientID, jd.iTargetSystem, jd.vTargetPosition, mShipDir);
+							SwitchSystem(iClientID, jd.iTargetSystem, jd.vTargetPosition, mShipDir); 
 						}
 
 						// Find all ships within the jump field including the one with the jump engine.
 						if (jd.arch.field_range > 0)
 						{
 							struct PlayerData *pPD = 0;
-							while (pPD = Players.traverse_active(pPD))
+							while(pPD = Players.traverse_active(pPD))
 							{
 								uint iSystemID2;
 								pub::SpaceObj::GetSystem(pPD->iShipID, iSystemID2);
@@ -808,33 +807,32 @@ namespace HyperJump
 									// Restrict some ships from jumping, this is for the jumpers
 									Archetype::Ship *ship = Archetype::GetShip(pPD->iShipArchetype);
 									wstring playershiparch = stows(ship->szName);
-									if (mapRestrictedShips.find(playershiparch) != mapRestrictedShips.end() && JumpWhiteListEnabled == 1)
+									if (mapRestrictedShips.find(playershiparch) != mapRestrictedShips.end() && JumpWhiteListEnabled == 1) 
 									{
-										PrintUserCmdText(pPD->iOnlineID, L"ERR Ship is not allowed to jump.");
+										PrintUserCmdText(pPD->iOnlineID, L"ERR Ship is not allowed to jump."); 
 									}
-									else
+									else 
 									{
-										PrintUserCmdText(pPD->iOnlineID, L"Jumping...");
+									PrintUserCmdText(pPD->iOnlineID, L"Jumping...");
 
-										if (HookExt::IniGetB(iClientID, "event.enabled"))
-										{
-											string eventid = wstos(HookExt::IniGetWS(iClientID, "event.eventid"));
+									if (HookExt::IniGetB(iClientID, "event.enabled"))
+									{
+										string eventid = wstos(HookExt::IniGetWS(iClientID, "event.eventid"));
 
-											//else disable event mode
-											HookExt::IniSetB(iClientID, "event.enabled", false);
-											HookExt::IniSetWS(iClientID, "event.eventid", L"");
-											HookExt::IniSetI(iClientID, "event.quantity", 0);
-											PrintUserCmdText(iClientID, L"You have been unregistered from the event.");
-										}
-
-										Vector vNewTargetPosition;
-										vNewTargetPosition.x = jd.vTargetPosition.x + (vPosition.x - vPosition2.x);
-										vNewTargetPosition.y = jd.vTargetPosition.y + (vPosition.y - vPosition2.y);
-										vNewTargetPosition.z = jd.vTargetPosition.z + (vPosition.z - vPosition2.z);
-										pub::Audio::PlaySoundEffect(pPD->iOnlineID, CreateID("dsy_jumpdrive_activate"));
-										pub::SpaceObj::DrainShields(pPD->iShipID);
-										SwitchSystem(pPD->iOnlineID, jd.iTargetSystem, vNewTargetPosition, mShipDir2);
+										//else disable event mode
+										HookExt::IniSetB(iClientID, "event.enabled", false);
+										HookExt::IniSetWS(iClientID, "event.eventid", L"");
+										HookExt::IniSetI(iClientID, "event.quantity", 0);
+										PrintUserCmdText(iClientID, L"You have been unregistered from the event.");
 									}
+
+									Vector vNewTargetPosition;
+									vNewTargetPosition.x = jd.vTargetPosition.x + (vPosition.x - vPosition2.x);
+									vNewTargetPosition.y = jd.vTargetPosition.y + (vPosition.y - vPosition2.y);
+									vNewTargetPosition.z = jd.vTargetPosition.z + (vPosition.z - vPosition2.z);
+									pub::Audio::PlaySoundEffect(pPD->iOnlineID, CreateID("dsy_jumpdrive_activate"));
+									pub::SpaceObj::DrainShields(pPD->iShipID);
+									SwitchSystem(pPD->iOnlineID, jd.iTargetSystem, vNewTargetPosition, mShipDir2); }
 								}
 							}
 						}
@@ -899,7 +897,7 @@ namespace HyperJump
 					// skip to the next player.
 					if (!jd.charging_on)
 					{
-						PrintUserCmdText(iClientID, L"Jump drive charging failed");
+						PrintUserCmdText(iClientID, L"Jump drive charging failed");				
 						pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 						SetFuse(iClientID, 0);
 						StopChargeFuses(iClientID);
@@ -913,7 +911,7 @@ namespace HyperJump
 						jd.curr_charge = jd.arch.can_jump_charge;
 						if (!jd.charging_complete)
 						{
-							PrintUserCmdText(iClientID, L"Jump drive charging complete, ready to jump");
+							PrintUserCmdText(iClientID, L"Jump drive charging complete, ready to jump");				
 							pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_complete"));
 							jd.charging_complete = true;
 						}
@@ -924,14 +922,14 @@ namespace HyperJump
 					}
 
 
-					uint expected_charge_status = (uint)(jd.curr_charge / jd.arch.can_jump_charge * 10);
+					uint expected_charge_status = (uint)(jd.curr_charge/jd.arch.can_jump_charge * 10);
 					if (jd.charge_status != expected_charge_status)
 					{
 						jd.charge_status = expected_charge_status;
-						PrintUserCmdText(iClientID, L"Jump drive charge %0.0f%%", (jd.curr_charge / jd.arch.can_jump_charge)*100.0f);
-
+						PrintUserCmdText(iClientID, L"Jump drive charge %0.0f%%", (jd.curr_charge/jd.arch.can_jump_charge)*100.0f);
+												
 						// Find the currently expected charge fuse
-						uint charge_fuse_idx = (uint)((jd.curr_charge / jd.arch.can_jump_charge) * (jd.arch.charge_fuse.size() - 1));
+						uint charge_fuse_idx = (uint)((jd.curr_charge/jd.arch.can_jump_charge) * (jd.arch.charge_fuse.size() - 1));
 						if (charge_fuse_idx >= jd.arch.charge_fuse.size())
 							charge_fuse_idx = jd.arch.charge_fuse.size() - 1;
 
@@ -962,13 +960,13 @@ namespace HyperJump
 		}
 
 		// If the ship has docked or died remove the client.	
-		foreach(lstOldClients, uint, iClientID)
+		foreach (lstOldClients, uint, iClientID)
 		{
 			mapJumpDrives.erase(*iClientID);
 		}
 	}
 
-
+		
 	void HyperJump::SendDeathMsg(const wstring &wscMsg, uint iSystem, uint iClientIDVictim, uint iClientIDKiller)
 	{
 		if (mapActiveBeacons.find(iClientIDVictim) != mapActiveBeacons.end())
@@ -985,7 +983,7 @@ namespace HyperJump
 			SwitchOut = (PBYTE)hModServer + 0xf600;
 
 			DWORD dummy;
-			VirtualProtect(SwitchOut + 0xd7, 200, PAGE_EXECUTE_READWRITE, &dummy);
+			VirtualProtect(SwitchOut+0xd7, 200, PAGE_EXECUTE_READWRITE, &dummy);
 		}
 
 		// Patch the system switch out routine to put the ship in a
@@ -995,43 +993,43 @@ namespace HyperJump
 			SwitchOut[0x0d7] = 0xeb;				// ignore exit object
 			SwitchOut[0x0d8] = 0x40;
 			SwitchOut[0x119] = 0xbb;				// set the destination system
-			*(PDWORD)(SwitchOut + 0x11a) = mapDeferredJumps[iClientID].system;
+			*(PDWORD)(SwitchOut+0x11a) = mapDeferredJumps[iClientID].system;
 			SwitchOut[0x266] = 0x45;				// don't generate warning
-			*(float*)(SwitchOut + 0x2b0) = mapDeferredJumps[iClientID].pos.z;		// set entry location
-			*(float*)(SwitchOut + 0x2b8) = mapDeferredJumps[iClientID].pos.y;
-			*(float*)(SwitchOut + 0x2c0) = mapDeferredJumps[iClientID].pos.x;
-			*(float*)(SwitchOut + 0x2c8) = mapDeferredJumps[iClientID].ornt.data[2][2];
-			*(float*)(SwitchOut + 0x2d0) = mapDeferredJumps[iClientID].ornt.data[1][1];
-			*(float*)(SwitchOut + 0x2d8) = mapDeferredJumps[iClientID].ornt.data[0][0];
-			*(float*)(SwitchOut + 0x2e0) = mapDeferredJumps[iClientID].ornt.data[2][1];
-			*(float*)(SwitchOut + 0x2e8) = mapDeferredJumps[iClientID].ornt.data[2][0];
-			*(float*)(SwitchOut + 0x2f0) = mapDeferredJumps[iClientID].ornt.data[1][2];
-			*(float*)(SwitchOut + 0x2f8) = mapDeferredJumps[iClientID].ornt.data[1][0];
-			*(float*)(SwitchOut + 0x300) = mapDeferredJumps[iClientID].ornt.data[0][2];
-			*(float*)(SwitchOut + 0x308) = mapDeferredJumps[iClientID].ornt.data[0][1];
-			*(PDWORD)(SwitchOut + 0x388) = 0x03ebc031;		// ignore entry object
+			*(float*)(SwitchOut+0x2b0) = mapDeferredJumps[iClientID].pos.z;		// set entry location
+			*(float*)(SwitchOut+0x2b8) = mapDeferredJumps[iClientID].pos.y;
+			*(float*)(SwitchOut+0x2c0) = mapDeferredJumps[iClientID].pos.x;
+			*(float*)(SwitchOut+0x2c8) = mapDeferredJumps[iClientID].ornt.data[2][2];
+			*(float*)(SwitchOut+0x2d0) = mapDeferredJumps[iClientID].ornt.data[1][1];
+			*(float*)(SwitchOut+0x2d8) = mapDeferredJumps[iClientID].ornt.data[0][0];
+			*(float*)(SwitchOut+0x2e0) = mapDeferredJumps[iClientID].ornt.data[2][1];
+			*(float*)(SwitchOut+0x2e8) = mapDeferredJumps[iClientID].ornt.data[2][0];
+			*(float*)(SwitchOut+0x2f0) = mapDeferredJumps[iClientID].ornt.data[1][2];
+			*(float*)(SwitchOut+0x2f8) = mapDeferredJumps[iClientID].ornt.data[1][0];
+			*(float*)(SwitchOut+0x300) = mapDeferredJumps[iClientID].ornt.data[0][2];
+			*(float*)(SwitchOut+0x308) = mapDeferredJumps[iClientID].ornt.data[0][1];
+			*(PDWORD)(SwitchOut+0x388) = 0x03ebc031;		// ignore entry object
 			mapDeferredJumps.erase(iClientID);
 			pub::SpaceObj::SetInvincible(iShip, false, false, 0);
-			Server.SystemSwitchOutComplete(iShip, iClientID);
+			Server.SystemSwitchOutComplete(iShip,iClientID);
 			SwitchOut[0x0d7] = 0x0f;
 			SwitchOut[0x0d8] = 0x84;
 			SwitchOut[0x119] = 0x87;
-			*(PDWORD)(SwitchOut + 0x11a) = 0x1b8;
-			*(PDWORD)(SwitchOut + 0x25d) = 0x1cf7f;
+			*(PDWORD)(SwitchOut+0x11a) = 0x1b8;
+			*(PDWORD)(SwitchOut+0x25d) = 0x1cf7f;
 			SwitchOut[0x266] = 0x1a;
-			*(float*)(SwitchOut + 0x2b0) =
-				*(float*)(SwitchOut + 0x2b8) =
-				*(float*)(SwitchOut + 0x2c0) = 0;
-			*(float*)(SwitchOut + 0x2c8) =
-				*(float*)(SwitchOut + 0x2d0) =
-				*(float*)(SwitchOut + 0x2d8) = 1;
-			*(float*)(SwitchOut + 0x2e0) =
-				*(float*)(SwitchOut + 0x2e8) =
-				*(float*)(SwitchOut + 0x2f0) =
-				*(float*)(SwitchOut + 0x2f8) =
-				*(float*)(SwitchOut + 0x300) =
-				*(float*)(SwitchOut + 0x308) = 0;
-			*(PDWORD)(SwitchOut + 0x388) = 0xcf8b178b;
+			*(float*)(SwitchOut+0x2b0) =
+				*(float*)(SwitchOut+0x2b8) =
+				*(float*)(SwitchOut+0x2c0) = 0;
+			*(float*)(SwitchOut+0x2c8) =
+				*(float*)(SwitchOut+0x2d0) =
+				*(float*)(SwitchOut+0x2d8) = 1;
+			*(float*)(SwitchOut+0x2e0) =
+				*(float*)(SwitchOut+0x2e8) =
+				*(float*)(SwitchOut+0x2f0) =
+				*(float*)(SwitchOut+0x2f8) =
+				*(float*)(SwitchOut+0x300) =
+				*(float*)(SwitchOut+0x308) = 0;
+			*(PDWORD)(SwitchOut+0x388) = 0xcf8b178b;
 
 			return true;
 		}
@@ -1058,14 +1056,14 @@ namespace HyperJump
 		}
 
 		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK)
+		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false)!=HKE_OK)
 		{
 			cmds->Print(L"ERR Not in space\n");
 			return;
 		}
 
 		HKPLAYERINFO targetPlyr;
-		if (HkGetPlayerInfo(wscCharname, targetPlyr, false) != HKE_OK || targetPlyr.iShip == 0)
+		if (HkGetPlayerInfo(wscCharname, targetPlyr, false)!=HKE_OK || targetPlyr.iShip==0)
 		{
 			cmds->Print(L"ERR Player not found or not in space\n");
 			return;
@@ -1091,13 +1089,13 @@ namespace HyperJump
 		}
 
 		HKPLAYERINFO info;
-		if (HkGetPlayerInfo(wscCharname, info, false) != HKE_OK)
+		if (HkGetPlayerInfo(wscCharname, info, false)!=HKE_OK)
 		{
 			cmds->Print(L"ERR Player not found\n");
 			return true;
 		}
 
-		if (info.iShip == 0)
+		if (info.iShip==0)
 		{
 			cmds->Print(L"ERR Player not in space\n");
 			return true;
@@ -1108,19 +1106,19 @@ namespace HyperJump
 		while (baseinfo)
 		{
 			wstring basename = HkGetWStringFromIDS(baseinfo->iBaseIDS);
-			if (ToLower(basename).find(ToLower(wscTargetBaseName)) == 0)
+			if (ToLower(basename).find(ToLower(wscTargetBaseName))==0)
 			{
 				pub::Player::ForceLand(info.iClientID, baseinfo->iBaseID);
 				if (info.iSystem != baseinfo->iSystemID)
 				{
-					Server.BaseEnter(baseinfo->iBaseID, info.iClientID);
-					Server.BaseExit(baseinfo->iBaseID, info.iClientID);
+					Server.BaseEnter(baseinfo->iBaseID,info.iClientID);
+					Server.BaseExit(baseinfo->iBaseID,info.iClientID);
 					wstring wscCharFileName;
-					HkGetCharFileName(info.wscCharname, wscCharFileName);
+					HkGetCharFileName(info.wscCharname,wscCharFileName);
 					wscCharFileName += L".fl";
 					CHARACTER_ID cID;
-					strcpy(cID.szCharFilename, wstos(wscCharFileName.substr(0, 14)).c_str());
-					Server.CharacterSelect(cID, info.iClientID); \
+					strcpy(cID.szCharFilename,wstos(wscCharFileName.substr(0,14)).c_str());
+					Server.CharacterSelect(cID, info.iClientID);\
 				}
 				return true;
 			}
@@ -1132,19 +1130,19 @@ namespace HyperJump
 		while (baseinfo)
 		{
 			wstring basename = HkGetWStringFromIDS(baseinfo->iBaseIDS);
-			if (ToLower(basename).find(ToLower(wscTargetBaseName)) != -1)
+			if (ToLower(basename).find(ToLower(wscTargetBaseName))!=-1)
 			{
 				pub::Player::ForceLand(info.iClientID, baseinfo->iBaseID);
 				if (info.iSystem != baseinfo->iSystemID)
 				{
-					Server.BaseEnter(baseinfo->iBaseID, info.iClientID);
-					Server.BaseExit(baseinfo->iBaseID, info.iClientID);
+					Server.BaseEnter(baseinfo->iBaseID,info.iClientID);
+					Server.BaseExit(baseinfo->iBaseID,info.iClientID);
 					wstring wscCharFileName;
-					HkGetCharFileName(info.wscCharname, wscCharFileName);
+					HkGetCharFileName(info.wscCharname,wscCharFileName);
 					wscCharFileName += L".fl";
 					CHARACTER_ID cID;
-					strcpy(cID.szCharFilename, wstos(wscCharFileName.substr(0, 14)).c_str());
-					Server.CharacterSelect(cID, info.iClientID); \
+					strcpy(cID.szCharFilename,wstos(wscCharFileName.substr(0,14)).c_str());
+					Server.CharacterSelect(cID, info.iClientID);\
 				}
 				return true;
 			}
@@ -1165,14 +1163,14 @@ namespace HyperJump
 		}
 
 		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
+		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false)!=HKE_OK || adminPlyr.iShip==0)
 		{
 			cmds->Print(L"ERR Not in space\n");
 			return;
 		}
 
 		HKPLAYERINFO targetPlyr;
-		if (HkGetPlayerInfo(wscCharname, targetPlyr, false) != HKE_OK)
+		if (HkGetPlayerInfo(wscCharname, targetPlyr, false)!=HKE_OK)
 		{
 			cmds->Print(L"ERR Player not found\n");
 			return;
@@ -1191,7 +1189,7 @@ namespace HyperJump
 	/** Move to location */
 	void HyperJump::AdminCmd_Move(CCmds* cmds, float x, float y, float z)
 	{
-		if (cmds->ArgStrToEnd(1).length() == 0)
+		if (cmds->ArgStrToEnd(1).length()==0)
 		{
 			cmds->Print(L"ERR Usage: move x y z\n");
 			return;
@@ -1204,7 +1202,7 @@ namespace HyperJump
 		}
 
 		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
+		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false)!=HKE_OK || adminPlyr.iShip==0)
 		{
 			cmds->Print(L"ERR Not in space\n");
 			return;
@@ -1224,7 +1222,7 @@ namespace HyperJump
 	bool InitJumpDriveInfo(uint iClientID)
 	{
 		// Initialise the drive parameters for this ship
-		if (mapJumpDrives.find(iClientID) == mapJumpDrives.end())
+		if (mapJumpDrives.find(iClientID)==mapJumpDrives.end())
 		{
 			mapJumpDrives[iClientID].arch.nickname = 0;
 			mapJumpDrives[iClientID].arch.can_jump_charge = 0;
@@ -1285,7 +1283,7 @@ namespace HyperJump
 	bool InitSurveyInfo(uint iClientID)
 	{
 		// Initialise the drive parameters for this ship
-		if (mapSurvey.find(iClientID) == mapSurvey.end())
+		if (mapSurvey.find(iClientID)==mapSurvey.end())
 		{
 			mapSurvey[iClientID].arch.nickname = 0;
 			mapSurvey[iClientID].arch.survey_complete_charge = 0;
@@ -1326,7 +1324,7 @@ namespace HyperJump
 
 		if (!InitSurveyInfo(iClientID))
 		{
-			PrintUserCmdText(iClientID, L"Survey module not available");
+			PrintUserCmdText(iClientID, L"Survey module not available");			
 			return true;
 		}
 
@@ -1335,12 +1333,12 @@ namespace HyperJump
 		CShip* cship = (CShip*)HkGetEqObjFromObjRW((IObjRW*)obj);
 		if (cship->get_max_power() < sm.arch.power)
 		{
-			PrintUserCmdText(iClientID, L"Insufficient power to start survey module");
+			PrintUserCmdText(iClientID, L"Insufficient power to start survey module");			
 			return true;
 		}
 
 		HKPLAYERINFO p;
-		if (HkGetPlayerInfo((const wchar_t*)Players.GetActiveCharacterName(iClientID), p, false) != HKE_OK || p.iShip == 0)
+		if (HkGetPlayerInfo((const wchar_t*) Players.GetActiveCharacterName(iClientID), p, false)!=HKE_OK || p.iShip==0)
 		{
 			PrintUserCmdText(iClientID, L"ERR Not in space");
 			return true;
@@ -1361,13 +1359,13 @@ namespace HyperJump
 		sm.charging_on = !sm.charging_on;
 		if (sm.charging_on)
 		{
-			PrintUserCmdText(iClientID, L"Survey started");
+			PrintUserCmdText(iClientID, L"Survey started");			
 			sm.curr_charge = 0;
 			return true;
 		}
 		else
 		{
-			PrintUserCmdText(iClientID, L"Survey aborted");
+			PrintUserCmdText(iClientID, L"Survey aborted");			
 			sm.curr_charge = 0;
 			return true;
 		}
@@ -1377,7 +1375,7 @@ namespace HyperJump
 	{
 		if (!InitJumpDriveInfo(iClientID))
 		{
-			PrintUserCmdText(iClientID, L"Jump drive not available");
+			PrintUserCmdText(iClientID, L"Jump drive not available");			
 			return true;
 		}
 
@@ -1392,11 +1390,11 @@ namespace HyperJump
 		}
 
 		char ibuf[HCOORD_SIZE];
-		for (uint i = 0, p = 0; i < HCOORD_SIZE && (p + 1) < sbuf.size(); i++, p += 2)
+		for (uint i=0, p=0; i<HCOORD_SIZE && (p+1)<sbuf.size(); i++, p+=2)
 		{
 			char buf[3];
 			buf[0] = sbuf[p];
-			buf[1] = sbuf[p + 1];
+			buf[1] = sbuf[p+1];
 			buf[2] = 0;
 			ibuf[i] = (char)strtoul(buf, 0, 16);
 		}
@@ -1409,7 +1407,7 @@ namespace HyperJump
 
 		// Calculate a simple parity check
 		WORD parity = 0;
-		for (int i = 2; i < HCOORD_SIZE; i++)
+		for (int i=2; i<HCOORD_SIZE; i++)
 			parity += obuf[i];
 
 		if (coords.parity != parity)
@@ -1435,7 +1433,7 @@ namespace HyperJump
 		if (coords.time < time(0))
 		{
 			PrintUserCmdText(iClientID, L"Warning old coordinates detected. Jump not recommended");
-			coords.accuracy *= rand() % 6 + 1;
+			coords.accuracy *= rand()%6 + 1;
 		}
 
 		jd.iTargetSystem = coords.system;
@@ -1451,9 +1449,9 @@ namespace HyperJump
 			*(float*)&jd.vTargetPosition.z);
 
 		int wiggle_factor = (int)coords.accuracy;
-		jd.vTargetPosition.x += ((rand() * 10) % wiggle_factor) - (wiggle_factor / 2);
-		jd.vTargetPosition.y += ((rand() * 10) % wiggle_factor) - (wiggle_factor / 2);
-		jd.vTargetPosition.z += ((rand() * 10) % wiggle_factor) - (wiggle_factor / 2);
+		jd.vTargetPosition.x += ((rand()*10) % wiggle_factor) - (wiggle_factor/2);
+		jd.vTargetPosition.y += ((rand()*10) % wiggle_factor) - (wiggle_factor/2);
+		jd.vTargetPosition.z += ((rand()*10) % wiggle_factor) - (wiggle_factor/2);
 
 		return true;
 	}
@@ -1464,14 +1462,14 @@ namespace HyperJump
 		IObjInspectImpl *obj = HkGetInspect(iClientID);
 		if (!obj)
 		{
-			PrintUserCmdText(iClientID, L"Jump drive charging failed");
+			PrintUserCmdText(iClientID, L"Jump drive charging failed");			
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 			return true;
 		}
 
 		if (!InitJumpDriveInfo(iClientID))
 		{
-			PrintUserCmdText(iClientID, L"Jump drive not available");
+			PrintUserCmdText(iClientID, L"Jump drive not available");			
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 			return true;
 		}
@@ -1481,7 +1479,7 @@ namespace HyperJump
 		CShip* cship = (CShip*)HkGetEqObjFromObjRW((IObjRW*)obj);
 		if (cship->get_max_power() < jd.arch.power)
 		{
-			PrintUserCmdText(iClientID, L"Insufficient power to charge jumpdrive");
+			PrintUserCmdText(iClientID, L"Insufficient power to charge jumpdrive");			
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 			return true;
 		}
@@ -1544,7 +1542,7 @@ namespace HyperJump
 		IObjInspectImpl *obj = HkGetInspect(iClientID);
 		if (!obj)
 		{
-			PrintUserCmdText(iClientID, L"Jump drive charging failed");
+			PrintUserCmdText(iClientID, L"Jump drive charging failed");			
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 			return true;
 		}
@@ -1552,7 +1550,7 @@ namespace HyperJump
 		// If no jumpdrive, report a warning.
 		if (!InitJumpDriveInfo(iClientID))
 		{
-			PrintUserCmdText(iClientID, L"Jump drive not ready");
+			PrintUserCmdText(iClientID, L"Jump drive not ready");			
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 			return true;
 		}
@@ -1562,7 +1560,7 @@ namespace HyperJump
 		// If insufficient charging, report a warning
 		if (!jd.charging_complete)
 		{
-			PrintUserCmdText(iClientID, L"Jump drive not ready");
+			PrintUserCmdText(iClientID, L"Jump drive not ready");			
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_not_ready"));
 			return true;
 		}
@@ -1618,12 +1616,11 @@ namespace HyperJump
 		return true;
 	}
 
-	time_t filetime_to_timet(const FILETIME& ft) {
+	time_t filetime_to_timet(const FILETIME& ft){
 		ULARGE_INTEGER ull;
 		ull.LowPart = ft.dwLowDateTime;
 		ull.HighPart = ft.dwHighDateTime;
-		return ull.QuadPart / 10000000ULL - 11644473600ULL;
-	}
+		return ull.QuadPart / 10000000ULL - 11644473600ULL;}
 
 	// Move the ship's starting position randomly if it has been logged out in space.
 	void HyperJump::PlayerLaunch(unsigned int iShip, unsigned int iClientID)
@@ -1635,7 +1632,7 @@ namespace HyperJump
 		if (HkFLIniGet((const wchar_t*)Players.GetActiveCharacterName(iClientID), L"tstamp", wscTimeStamp) != HKE_OK)
 			return;
 
-		FILETIME ft;
+		FILETIME ft; 
 		ft.dwHighDateTime = strtoul(GetParam(wstos(wscTimeStamp), ',', 0).c_str(), 0, 10);
 		ft.dwLowDateTime = strtoul(GetParam(wstos(wscTimeStamp), ',', 1).c_str(), 0, 10);
 		time_t lastTime = filetime_to_timet(ft);
@@ -1653,7 +1650,7 @@ namespace HyperJump
 		if (drift > MAX_DRIFT)
 			drift = MAX_DRIFT;
 
-		drift *= ((2.0f * rand() / (float)RAND_MAX) - 1.0f);
+		drift *= ( (2.0f * rand() / (float)RAND_MAX) - 1.0f);
 
 		// Adjust the ship's position.
 		Vector pos = { Players[iClientID].vPosition.x, Players[iClientID].vPosition.y, Players[iClientID].vPosition.z };
@@ -1672,7 +1669,7 @@ namespace HyperJump
 				mapSurvey[iClientID].curr_charge = 0;
 				mapSurvey[iClientID].charging_on = false;
 				PrintUserCmdText(iClientID, L"Hyperspace survey disrupted, restart required");
-			}
+			}			
 		}
 
 		//TEMPORARY: Allow JDs to be disrupted with CDs
@@ -1681,12 +1678,12 @@ namespace HyperJump
 			if (mapJumpDrives[iClientID].charging_on && mapJumpDrives[iClientID].arch.cd_disrupts_charge)
 			{
 				if (dmg->get_cause() == 6)
-				{
-					mapJumpDrives[iClientID].charging_on = false;
-					PrintUserCmdText(iClientID, L"Jump drive disrupted. Charging failed.");
-					pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
-					SetFuse(iClientID, 0);
-					StopChargeFuses(iClientID);
+				{				
+				mapJumpDrives[iClientID].charging_on = false;
+				PrintUserCmdText(iClientID, L"Jump drive disrupted. Charging failed.");
+				pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
+				SetFuse(iClientID, 0);
+				StopChargeFuses(iClientID);
 				}
 			}
 		}
@@ -1694,8 +1691,9 @@ namespace HyperJump
 
 	bool HyperJump::UserCmd_DeployBeacon(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
 	{
+
 		HKPLAYERINFO p;
-		if (HkGetPlayerInfo((const wchar_t*)Players.GetActiveCharacterName(iClientID), p, false) != HKE_OK || p.iShip == 0)
+		if (HkGetPlayerInfo((const wchar_t*) Players.GetActiveCharacterName(iClientID), p, false)!=HKE_OK || p.iShip==0)
 		{
 			PrintUserCmdText(iClientID, L"ERR Not in space");
 			return true;
@@ -1707,7 +1705,7 @@ namespace HyperJump
 			return true;
 		}
 
-		for (map<uint, BEACONTIMER>::iterator i = mapActiveBeacons.begin(); i != mapActiveBeacons.end(); ++i)
+		for (map<uint, BEACONTIMER>::iterator i = mapActiveBeacons.begin(); i != mapActiveBeacons.end(); ++i) 
 		{
 			if (i->first == iClientID)
 			{
@@ -1900,7 +1898,7 @@ namespace HyperJump
 				pub::Player::SendNNMessage(iTargetID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 				SetFuse(iTargetID, 0);
 				StopChargeFuses(iTargetID);
-			}
+			}			
 		}
 	}
 

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -18,15 +18,12 @@
 #include <set>
 #include <algorithm>
 
-//#include "ZoneUtilities.h"
 #include <PluginUtilities.h>
 #include "Main.h"
 #include <hookext_exports.h>
 
 namespace HyperJump
 {
-	bool InitJumpDriveInfo(uint iClientID);
-
 	// Check that the item is a ship, cargo or equipment item is valid
 	static uint CreateValidID(const char *nickname)
 	{
@@ -39,7 +36,7 @@ namespace HyperJump
 			ConPrint(L"ERROR: item '%s' is not valid\n", stows(nickname).c_str());
 		}
 
-		return item;	
+		return item;
 	}
 
 	// Ships restricted from jumping
@@ -61,8 +58,7 @@ namespace HyperJump
 
 	struct SYSTEM_JUMPLIST
 	{
-		uint nickname;
-		map<uint, uint> mapSystemsList;
+		vector<uint> visibleSystemsList;
 	};
 	static map<uint, SYSTEM_JUMPLIST> mapJumpSystems;
 
@@ -73,20 +69,6 @@ namespace HyperJump
 	static int BeaconTime = 120;
 	static int BeaconCooldown = 300;
 	static uint BeaconFuse = 0;
-
-	/// Zone testing state and lists.
-	/*
-	struct TESTBOT
-	{
-		bool bBaseTest;
-		int iCheckZoneTime;
-		int iCheckSystemOrBase;
-		int iCheckZonesTimer;
-		int iCheckTestedZones;
-		list<ZONE> lstCheckZones;
-	};
-	static map<uint, TESTBOT> mapTestBots;
-	*/
 
 	struct DEFERREDJUMPS
 	{
@@ -144,7 +126,6 @@ namespace HyperJump
 		int jump_timer;
 		uint iTargetSystem;
 		Vector vTargetPosition;
-		bool rekt;
 
 	};
 	static map<uint, JUMPDRIVE> mapJumpDrives;
@@ -186,16 +167,13 @@ namespace HyperJump
 
 	static string set_scEncryptKey = "secretcode";
 
-	static map<uint, bool> set_death_systems; // Systems the user is killed upon entering
-	static map<uint, bool> set_banned_systems;  // Systems that cannot be random jumped to.
-
 	static wstring FormatCoords(char* ibuf)
 	{
 		wstring sbuf;
 		wchar_t buf[100];
-		for (int i=0; i<HCOORD_SIZE; i++)
+		for (int i = 0; i < HCOORD_SIZE; i++)
 		{
-			if (i!=0 && (i%4)==0) sbuf += L"-";
+			if (i != 0 && (i % 4) == 0) sbuf += L"-";
 			_snwprintf(buf, sizeof(buf), L"%02X", (byte)ibuf[i]);
 			sbuf += buf;
 		}
@@ -206,67 +184,11 @@ namespace HyperJump
 	{
 		obuf[0] = ibuf[0];
 		obuf[1] = ibuf[1];
-		for (uint i=2, p=ibuf[0]%set_scEncryptKey.length(); i<HCOORD_SIZE; i++, p++)
+		for (uint i = 2, p = ibuf[0] % set_scEncryptKey.length(); i < HCOORD_SIZE; i++, p++)
 		{
 			if (p > set_scEncryptKey.length())
 				p = 0;
-			obuf[i] = ibuf[i]^set_scEncryptKey[p];
-		}
-	}
-
-	void Logging(const char *szString, ...)
-	{
-		char szBufString[1024];
-		va_list marker;
-		va_start(marker, szString);
-		_vsnprintf(szBufString, sizeof(szBufString)-1, szString, marker);
-
-		char szBuf[64];
-		time_t tNow = time(0);
-		struct tm *t = localtime(&tNow);
-		strftime(szBuf, sizeof(szBuf), "%d/%m/%Y %H:%M:%S", t);
-
-		FILE *Logfile = fopen(("./flhook_logs/flhook_cheaters.log"), "at");
-		if(Logfile)
-		{
-			fprintf(Logfile, "%s %s\n", szBuf, szBufString);
-			fflush(Logfile);
-			fclose(Logfile);
-		}	
-	}
-
-	void LogCheater(uint client, const wstring &reason)
-	{
-		CAccount *acc = Players.FindAccountFromClientID(client);
-
-		if (!HkIsValidClientID(client) || !acc)
-		{
-			AddLog("ERROR: invalid parameter in log cheater, clientid=%u acc=%08x reason=%s", client, acc, wstos(reason).c_str());
-			return;
-		}
-
-		//internal log
-		string scText = wstos(reason);
-		Logging("%s", scText.c_str());
-
-		// Set the kick timer to kick this player. We do this to break potential
-		// stack corruption.
-		HkDelayedKick(client, 1);
-
-		// Ban the account.
-		flstr *flStr = CreateWString(acc->wszAccID);
-		Players.BanAccount(*flStr, true);
-		FreeWString(flStr);
-
-		// Overwrite the ban file so that it contains the ban reason
-		wstring wscDir;
-		HkGetAccountDirName(acc, wscDir);
-		string scBanPath = scAcctPath + wstos(wscDir) + "\\banned";
-		FILE *file = fopen(scBanPath.c_str(), "wb");
-		if (file)
-		{
-			fprintf(file, "Autobanned by Hyperjump\n");
-			fclose(file);
+			obuf[i] = ibuf[i] ^ set_scEncryptKey[p];
 		}
 	}
 
@@ -299,7 +221,7 @@ namespace HyperJump
 		GetCurrentDirectory(sizeof(szCurDir), szCurDir);
 		string scCfgFile = string(szCurDir) + "\\flhook_plugins\\jump.cfg";
 		string scCfgFileSystemList = string(szCurDir) + "\\flhook_plugins\\jump_allowedsystems.cfg";
-	
+
 		int iItemID = 1;
 
 		INI_Reader ini;
@@ -311,29 +233,20 @@ namespace HyperJump
 				{
 					while (ini.read_value())
 					{
-						if (ini.is_value("death_system"))
+						if (ini.is_value("JumpWhiteListEnabled"))
 						{
-							set_death_systems[CreateID(ini.get_value_string(0))] = true;
-						}
-						else if (ini.is_value("banned_system"))
-						{
-							set_banned_systems[CreateID(ini.get_value_string(0))] = true;
-						}
-
-						else if (ini.is_value("JumpWhiteListEnabled"))
-						{
-						JumpWhiteListEnabled = ini.get_value_int(0);
-						ConPrint(L"HYPERJUMP NOTICE: Ship Whitelist is %u (1=On, 0=Off)\n", JumpWhiteListEnabled);
+							JumpWhiteListEnabled = ini.get_value_int(0);
+							ConPrint(L"HYPERJUMP NOTICE: Ship Whitelist is %u (1=On, 0=Off)\n", JumpWhiteListEnabled);
 						}
 						else if (ini.is_value("JumpSystemListEnabled"))
 						{
-						JumpSystemListEnabled = ini.get_value_int(0);
-						ConPrint(L"HYPERJUMP NOTICE: System Whitelist is %u (1=On, 0=Off)\n", JumpSystemListEnabled);
+							JumpSystemListEnabled = ini.get_value_int(0);
+							ConPrint(L"HYPERJUMP NOTICE: System Whitelist is %u (1=On, 0=Off)\n", JumpSystemListEnabled);
 						}
 						else if (ini.is_value("SurveyPlaneLimit"))
 						{
-						SurveyPlaneLimit = ini.get_value_int(0);
-						ConPrint(L"HYPERJUMP NOTICE: Survey Plane Limit is %u \n", SurveyPlaneLimit);
+							SurveyPlaneLimit = ini.get_value_int(0);
+							ConPrint(L"HYPERJUMP NOTICE: Survey Plane Limit is %u \n", SurveyPlaneLimit);
 						}
 						else if (ini.is_value("BeaconCommodity"))
 						{
@@ -351,7 +264,7 @@ namespace HyperJump
 						{
 							BeaconCooldown = ini.get_value_int(0);
 						}
-					}				
+					}
 				}
 				else if (ini.is_header("shiprestrictions"))
 				{
@@ -372,7 +285,7 @@ namespace HyperJump
 					while (ini.read_value())
 					{
 						if (ini.is_value("nickname"))
-						{ 
+						{
 							jd.nickname = CreateValidID(ini.get_value_string(0));
 						}
 						else if (ini.is_value("can_jump_charge"))
@@ -422,7 +335,7 @@ namespace HyperJump
 					while (ini.read_value())
 					{
 						if (ini.is_value("nickname"))
-						{ 
+						{
 							hs.nickname = CreateValidID(ini.get_value_string(0));
 						}
 						else if (ini.is_value("survey_complete_charge"))
@@ -471,7 +384,7 @@ namespace HyperJump
 					}
 					mapBeaconMatrix[bm.nickname] = bm;
 				}
-				
+
 			}
 			if (BeaconCommodity == 0)
 			{
@@ -490,21 +403,20 @@ namespace HyperJump
 			{
 				if (ini.is_header("system"))
 				{
+					uint nickname;
 					SYSTEM_JUMPLIST jumpsyslist;
 					while (ini.read_value())
 					{
 						if (ini.is_value("nickname"))
-						{ 
-							jumpsyslist.nickname = CreateID(ini.get_value_string(0));
+						{
+							nickname = CreateID(ini.get_value_string(0));
 						}
 						else if (ini.is_value("jump"))
 						{
-							uint destsystem = CreateID(ini.get_value_string(0));
-							int dummy = 1;
-							jumpsyslist.mapSystemsList[destsystem] = dummy;
+							jumpsyslist.visibleSystemsList.push_back(CreateID(ini.get_value_string(0)));
 						}
 					}
-					mapJumpSystems[jumpsyslist.nickname] = jumpsyslist;
+					mapJumpSystems[nickname] = jumpsyslist;
 				}
 			}
 			ini.close();
@@ -559,11 +471,11 @@ namespace HyperJump
 		IObjInspectImpl *obj = HkGetInspect(iClientID);
 		if (obj)
 		{
-			foreach (mapJumpDrives[iClientID].active_charge_fuse, uint, fuse)
-				HkUnLightFuse((IObjRW*) obj, *fuse, 0);
+			foreach(mapJumpDrives[iClientID].active_charge_fuse, uint, fuse)
+				HkUnLightFuse((IObjRW*)obj, *fuse, 0);
 			mapJumpDrives[iClientID].active_charge_fuse.clear();
 		}
-	}			
+	}
 
 	bool HyperJump::UserCmd_ListJumpableSystems(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
 	{
@@ -573,32 +485,42 @@ namespace HyperJump
 		wstring wscSysName = HkGetWStringFromIDS(iSys->strid_name);
 
 		PrintUserCmdText(iClientID, L"Space kitteh knows you are in %s !", wscSysName.c_str());
-		
+
 		if (JumpWhiteListEnabled == 1)
 		{
-			for (map<uint, SYSTEM_JUMPLIST>::iterator iter = mapJumpSystems.begin(); iter!=mapJumpSystems.end(); iter++)
+			for (map<uint, SYSTEM_JUMPLIST>::iterator iter = mapJumpSystems.begin(); iter != mapJumpSystems.end(); iter++)
 			{
-			
-			SYSTEM_JUMPLIST &jumpsyslist = iter->second;
-				if (jumpsyslist.nickname == iSystemID) 
+				SYSTEM_JUMPLIST &jumpsyslist = iter->second;
+				if (iter->first == iSystemID)
 				{
-				PrintUserCmdText(iClientID, L"The script has found %s !", wscSysName.c_str());
-				PrintUserCmdText(iClientID, L"You are allowed to jump to:");
-			
-					for (map<uint, uint>::iterator i = jumpsyslist.mapSystemsList.begin(); i != jumpsyslist.mapSystemsList.end(); ++i) 
+					PrintUserCmdText(iClientID, L"The script has found %s !", wscSysName.c_str());
+					PrintUserCmdText(iClientID, L"You are allowed to jump to:");
+
+					for (auto &allowed_sys : jumpsyslist.visibleSystemsList)
 					{
-					const Universe::ISystem *iSysList = Universe::get_system(i->first);
-					wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
-					PrintUserCmdText(iClientID, L"|     %s", wscSysNameList.c_str());
+						const Universe::ISystem *iSysList = Universe::get_system(allowed_sys);
+						wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
+						PrintUserCmdText(iClientID, L"|     %s", wscSysNameList.c_str());
 					}
 				}
 			}
 		}
 		else
 		{
-			PrintUserCmdText(iClientID, L"Jump System Whitelisting is not enabled.");	
+			PrintUserCmdText(iClientID, L"Jump System Whitelisting is not enabled.");
 		}
 		return true;
+	}
+
+	bool IsSystemJumpable(uint systemFrom, uint systemTo)
+	{
+		auto allowedSystemIter = mapJumpSystems.find(systemFrom);
+
+		if (allowedSystemIter == mapJumpSystems.end())
+			return false;
+
+		auto &allowedSystems = allowedSystemIter->second.visibleSystemsList;
+		return find(allowedSystems.begin(), allowedSystems.end(), systemTo) != allowedSystems.end();
 	}
 
 	/** List ships restricted from jumping */
@@ -630,7 +552,7 @@ namespace HyperJump
 		}
 
 		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false)!=HKE_OK || adminPlyr.iShip==0)
+		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
 		{
 			cmds->Print(L"ERR Not in space\n");
 			return;
@@ -654,7 +576,7 @@ namespace HyperJump
 
 		// Calculate a simple parity check
 		WORD parity = 0;
-		for (int i=2; i<HCOORD_SIZE; i++)
+		for (int i = 2; i < HCOORD_SIZE; i++)
 			parity += ibuf[i];
 		coords.parity = parity;
 
@@ -674,7 +596,7 @@ namespace HyperJump
 
 		// Handle beacons
 
-		for (map<uint, BEACONTIMER>::iterator i = mapActiveBeacons.begin(); i != mapActiveBeacons.end(); ++i) 
+		for (map<uint, BEACONTIMER>::iterator i = mapActiveBeacons.begin(); i != mapActiveBeacons.end(); ++i)
 		{
 			BEACONTIMER &bc = i->second;
 
@@ -705,13 +627,13 @@ namespace HyperJump
 		}
 
 		// Handle survey charging
-		for (map<uint, SURVEY>::iterator iter = mapSurvey.begin(); iter!=mapSurvey.end(); iter++)
+		for (map<uint, SURVEY>::iterator iter = mapSurvey.begin(); iter != mapSurvey.end(); iter++)
 		{
 			uint iClientID = iter->first;
-			
+
 			uint iShip;
 			pub::Player::GetShip(iClientID, iShip);
-			if (iShip==0)
+			if (iShip == 0)
 			{
 				lstOldClients.push_back(iClientID);
 			}
@@ -741,7 +663,7 @@ namespace HyperJump
 					Vector dir1;
 					Vector dir2;
 					pub::SpaceObj::GetMotion(iShip, dir1, dir2);
-					if (dir1.x>5 || dir1.y>5 || dir1.z>5)
+					if (dir1.x > 5 || dir1.y > 5 || dir1.z > 5)
 					{
 						sm.charging_on = false;
 					}
@@ -776,28 +698,27 @@ namespace HyperJump
 
 						// Calculate a simple parity check
 						WORD parity = 0;
-						for (int i=2; i<HCOORD_SIZE; i++)
+						for (int i = 2; i < HCOORD_SIZE; i++)
 							parity += ibuf[i];
 						coords.parity = parity;
 
 						// Encrypt it
 						char obuf[HCOORD_SIZE];
 						EncryptDecrypt(ibuf, obuf);
-						PrintUserCmdText(iClientID, L"Hyperspace survey complete");
-						//PrintUserCmdText(iClientID, L"Raw: %s", FormatCoords(ibuf).c_str());		
+						PrintUserCmdText(iClientID, L"Hyperspace survey complete");	
 						PrintUserCmdText(iClientID, L"Coords: %s", FormatCoords(obuf).c_str());
 
 						lstOldClients.push_back(iClientID);
 					}
 					else if (time(0) % 10 == 0)
 					{
-						PrintUserCmdText(iClientID, L"Survey %0.0f%% complete", (sm.curr_charge/sm.arch.survey_complete_charge)*100.0f);				
+						PrintUserCmdText(iClientID, L"Survey %0.0f%% complete", (sm.curr_charge / sm.arch.survey_complete_charge)*100.0f);
 					}
 				}
 			}
 		}
 
-		foreach (lstOldClients, uint, iClientID)
+		foreach(lstOldClients, uint, iClientID)
 		{
 			mapSurvey.erase(*iClientID);
 		}
@@ -805,28 +726,19 @@ namespace HyperJump
 		lstOldClients.clear();
 
 		// Handle jump drive charging
-		for (map<uint, JUMPDRIVE>::iterator iter = mapJumpDrives.begin(); iter!=mapJumpDrives.end(); iter++)
+		for (map<uint, JUMPDRIVE>::iterator iter = mapJumpDrives.begin(); iter != mapJumpDrives.end(); iter++)
 		{
 			uint iClientID = iter->first;
-			
+
 			uint iShip;
 			pub::Player::GetShip(iClientID, iShip);
-			if (iShip==0)
+			if (iShip == 0)
 			{
 				lstOldClients.push_back(iClientID);
 			}
 			else
 			{
 				JUMPDRIVE &jd = iter->second;
-
-				//we end everything if the player was caught exploiting.
-				if (jd.rekt == true)
-				{
-					SetFuse(iClientID, 0);
-					StopChargeFuses(iClientID);
-					jd.jump_timer = 0;
-					continue;
-				}
 
 				if (jd.jump_timer > 0)
 				{
@@ -842,7 +754,7 @@ namespace HyperJump
 					jd.jump_timer--;
 					// Turn on the jumpdrive flash
 					if (jd.jump_timer == 7)
-					{	
+					{
 						jd.charging_complete = false;
 						jd.curr_charge = 0.0;
 						jd.charging_on = false;
@@ -867,20 +779,20 @@ namespace HyperJump
 						// Restrict some ships from jumping, this is for the jumpship
 						Archetype::Ship *ship = Archetype::GetShip(Players[iClientID].iShipArchetype);
 						wstring playershiparch = stows(ship->szName);
-						if (mapRestrictedShips.find(playershiparch) != mapRestrictedShips.end() && JumpWhiteListEnabled == 1) 
+						if (mapRestrictedShips.find(playershiparch) != mapRestrictedShips.end() && JumpWhiteListEnabled == 1)
 						{
-							PrintUserCmdText(iClientID, L"ERR Ship is not allowed to jump."); 
+							PrintUserCmdText(iClientID, L"ERR Ship is not allowed to jump.");
 						}
-						else 
+						else
 						{
-							SwitchSystem(iClientID, jd.iTargetSystem, jd.vTargetPosition, mShipDir); 
+							SwitchSystem(iClientID, jd.iTargetSystem, jd.vTargetPosition, mShipDir);
 						}
 
 						// Find all ships within the jump field including the one with the jump engine.
 						if (jd.arch.field_range > 0)
 						{
 							struct PlayerData *pPD = 0;
-							while(pPD = Players.traverse_active(pPD))
+							while (pPD = Players.traverse_active(pPD))
 							{
 								uint iSystemID2;
 								pub::SpaceObj::GetSystem(pPD->iShipID, iSystemID2);
@@ -896,33 +808,33 @@ namespace HyperJump
 									// Restrict some ships from jumping, this is for the jumpers
 									Archetype::Ship *ship = Archetype::GetShip(pPD->iShipArchetype);
 									wstring playershiparch = stows(ship->szName);
-									if (mapRestrictedShips.find(playershiparch) != mapRestrictedShips.end() && JumpWhiteListEnabled == 1) 
+									if (mapRestrictedShips.find(playershiparch) != mapRestrictedShips.end() && JumpWhiteListEnabled == 1)
 									{
-										PrintUserCmdText(pPD->iOnlineID, L"ERR Ship is not allowed to jump."); 
+										PrintUserCmdText(pPD->iOnlineID, L"ERR Ship is not allowed to jump.");
 									}
-									else 
+									else
 									{
-									//PrintUserCmdText(pPD->iOnlineID, playershiparch);
-									PrintUserCmdText(pPD->iOnlineID, L"Jumping...");
+										PrintUserCmdText(pPD->iOnlineID, L"Jumping...");
 
-									if (HookExt::IniGetB(iClientID, "event.enabled"))
-									{
-										string eventid = wstos(HookExt::IniGetWS(iClientID, "event.eventid"));
+										if (HookExt::IniGetB(iClientID, "event.enabled"))
+										{
+											string eventid = wstos(HookExt::IniGetWS(iClientID, "event.eventid"));
 
-										//else disable event mode
-										HookExt::IniSetB(iClientID, "event.enabled", false);
-										HookExt::IniSetWS(iClientID, "event.eventid", L"");
-										HookExt::IniSetI(iClientID, "event.quantity", 0);
-										PrintUserCmdText(iClientID, L"You have been unregistered from the event.");
+											//else disable event mode
+											HookExt::IniSetB(iClientID, "event.enabled", false);
+											HookExt::IniSetWS(iClientID, "event.eventid", L"");
+											HookExt::IniSetI(iClientID, "event.quantity", 0);
+											PrintUserCmdText(iClientID, L"You have been unregistered from the event.");
+										}
+
+										Vector vNewTargetPosition;
+										vNewTargetPosition.x = jd.vTargetPosition.x + (vPosition.x - vPosition2.x);
+										vNewTargetPosition.y = jd.vTargetPosition.y + (vPosition.y - vPosition2.y);
+										vNewTargetPosition.z = jd.vTargetPosition.z + (vPosition.z - vPosition2.z);
+										pub::Audio::PlaySoundEffect(pPD->iOnlineID, CreateID("dsy_jumpdrive_activate"));
+										pub::SpaceObj::DrainShields(pPD->iShipID);
+										SwitchSystem(pPD->iOnlineID, jd.iTargetSystem, vNewTargetPosition, mShipDir2);
 									}
-
-									Vector vNewTargetPosition;
-									vNewTargetPosition.x = jd.vTargetPosition.x + (vPosition.x - vPosition2.x);
-									vNewTargetPosition.y = jd.vTargetPosition.y + (vPosition.y - vPosition2.y);
-									vNewTargetPosition.z = jd.vTargetPosition.z + (vPosition.z - vPosition2.z);
-									pub::Audio::PlaySoundEffect(pPD->iOnlineID, CreateID("dsy_jumpdrive_activate"));
-									pub::SpaceObj::DrainShields(pPD->iShipID);
-									SwitchSystem(pPD->iOnlineID, jd.iTargetSystem, vNewTargetPosition, mShipDir2); }
 								}
 							}
 						}
@@ -940,17 +852,6 @@ namespace HyperJump
 					// (the switch out causes the ship to be invincible
 					else if (jd.jump_timer == 0)
 					{
-						// If this system is a system that kills on jump in then
-						// kill the ship
-						if (set_death_systems.find(jd.iTargetSystem) != set_death_systems.end())
-						{
-							IObjInspectImpl *obj = HkGetInspect(iClientID);
-							if (obj)
-							{
-								HkLightFuse((IObjRW*)obj, CreateID("death_comm"), 0.0f, 0.0f, 0.0f);
-							}
-						}
-
 						jd.iTargetSystem = 0;
 						jd.vTargetPosition.x = 0;
 						jd.vTargetPosition.y = 0;
@@ -998,7 +899,7 @@ namespace HyperJump
 					// skip to the next player.
 					if (!jd.charging_on)
 					{
-						PrintUserCmdText(iClientID, L"Jump drive charging failed");				
+						PrintUserCmdText(iClientID, L"Jump drive charging failed");
 						pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 						SetFuse(iClientID, 0);
 						StopChargeFuses(iClientID);
@@ -1012,7 +913,7 @@ namespace HyperJump
 						jd.curr_charge = jd.arch.can_jump_charge;
 						if (!jd.charging_complete)
 						{
-							PrintUserCmdText(iClientID, L"Jump drive charging complete, ready to jump");				
+							PrintUserCmdText(iClientID, L"Jump drive charging complete, ready to jump");
 							pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_complete"));
 							jd.charging_complete = true;
 						}
@@ -1023,14 +924,14 @@ namespace HyperJump
 					}
 
 
-					uint expected_charge_status = (uint)(jd.curr_charge/jd.arch.can_jump_charge * 10);
+					uint expected_charge_status = (uint)(jd.curr_charge / jd.arch.can_jump_charge * 10);
 					if (jd.charge_status != expected_charge_status)
 					{
 						jd.charge_status = expected_charge_status;
-						PrintUserCmdText(iClientID, L"Jump drive charge %0.0f%%", (jd.curr_charge/jd.arch.can_jump_charge)*100.0f);
-						
+						PrintUserCmdText(iClientID, L"Jump drive charge %0.0f%%", (jd.curr_charge / jd.arch.can_jump_charge)*100.0f);
+
 						// Find the currently expected charge fuse
-						uint charge_fuse_idx = (uint)((jd.curr_charge/jd.arch.can_jump_charge) * (jd.arch.charge_fuse.size() - 1));
+						uint charge_fuse_idx = (uint)((jd.curr_charge / jd.arch.can_jump_charge) * (jd.arch.charge_fuse.size() - 1));
 						if (charge_fuse_idx >= jd.arch.charge_fuse.size())
 							charge_fuse_idx = jd.arch.charge_fuse.size() - 1;
 
@@ -1061,122 +962,15 @@ namespace HyperJump
 		}
 
 		// If the ship has docked or died remove the client.	
-		foreach (lstOldClients, uint, iClientID)
+		foreach(lstOldClients, uint, iClientID)
 		{
 			mapJumpDrives.erase(*iClientID);
 		}
-
-		// Handle testbot jumping.
-		/*
-		for (map<uint, TESTBOT>::iterator iter = mapTestBots.begin(); iter!=mapTestBots.end(); iter++)
-		{
-			uint iClientID = iter->first;
-			TESTBOT &tb = iter->second;
-
-			if (tb.bBaseTest)
-			{
-				if (tb.iCheckZonesTimer>0)
-				{
-					tb.iCheckZonesTimer--;
-				}
-				else if (tb.iCheckZonesTimer==0)
-				{
-					tb.iCheckZonesTimer = tb.iCheckZoneTime;
-					tb.iCheckTestedZones++;
-					uint iSystem;
-					pub::Player::GetSystem(iClientID, iSystem);
-
-					uint iShip;
-					pub::Player::GetShip(iClientID, iShip);
-
-					// if ship is in base undock it
-					uint iBase;
-					pub::Player::GetBase(iClientID, iBase);
-					if (iBase)
-					{
-						PrintUserCmdText(iClientID, L"Launching iteration %d", tb.iCheckTestedZones);
-
-						Vector pos = {0,300000,0};
-						Matrix ornt = {0};
-						SwitchSystem(iClientID, iSystem, pos, ornt);
-					}
-					// if in space dock with specified base.
-					else if (iShip)
-					{
-						PrintUserCmdText(iClientID, L"Docking iteration %d", tb.iCheckTestedZones);
-
-						const struct Universe::IBase *baseinfo = Universe::get_base(tb.iCheckSystemOrBase);
-						pub::Player::ForceLand(iClientID, baseinfo->iBaseID);
-						if (iSystem != baseinfo->iSystemID)
-						{
-							Server.BaseEnter(baseinfo->iBaseID,iClientID);
-							Server.BaseExit(baseinfo->iBaseID,iClientID);
-							wstring wscCharFileName;
-							HkGetCharFileName((const wchar_t*)Players.GetActiveCharacterName(iClientID), wscCharFileName);
-							wscCharFileName += L".fl";
-							CHARACTER_ID cID;
-							strcpy(cID.szCharFilename,wstos(wscCharFileName.substr(0,14)).c_str());
-							Server.CharacterSelect(cID, iClientID);\
-						}
-					}
-				}
-			}
-			else
-			{
-				uint iSystem;
-				pub::Player::GetSystem(iter->first, iSystem);
-				if (tb.iCheckSystemOrBase==iSystem)
-				{
-					if (tb.iCheckZonesTimer>0)
-					{
-						if ((tb.iCheckZonesTimer%10)==0)
-							PrintUserCmdText(iClientID, L"Jump to next zone in %d seconds", tb.iCheckZonesTimer);
-						tb.iCheckZonesTimer--;
-					}
-					else if (tb.iCheckZonesTimer==0)
-					{
-						if (tb.lstCheckZones.size())
-						{
-							tb.iCheckZonesTimer = tb.iCheckZoneTime;
-							tb.iCheckTestedZones++;
-
-							const ZONE &lz = tb.lstCheckZones.front();
-							PrintUserCmdText(iClientID, L"Testing zone %s (%0.0f %0.0f %0.0f) iteration %d",
-								stows(lz.zoneNick).c_str(), lz.pos.x, lz.pos.y, lz.pos.z, tb.iCheckTestedZones);
-
-							uint iShip;
-							pub::Player::GetShip(iClientID, iShip);
-
-							Vector myLocation;
-							Matrix myRot;
-							pub::SpaceObj::GetLocation(iShip, myLocation, myRot);
-
-							HkRelocateClient(iClientID, lz.pos, myRot);
-							tb.lstCheckZones.pop_front();
-							tb.lstCheckZones.push_back(lz);
-						}
-					}
-				}
-			}
-		}
-		*/
 	}
 
-	
+
 	void HyperJump::SendDeathMsg(const wstring &wscMsg, uint iSystem, uint iClientIDVictim, uint iClientIDKiller)
 	{
-		// If someone killed a bot then take revenge
-		/*
-		map<uint, TESTBOT>::iterator iter = mapTestBots.find(iClientIDVictim);
-		if (iter!=mapTestBots.end())
-		{
-			PrintUserCmdText(iClientIDKiller, L"Err 0101010001110 Does not compute");
-			HkKill((const wchar_t*) Players.GetActiveCharacterName(iClientIDKiller));
-			return;
-		}
-		*/
-
-		//Disable the beacon if the player died
 		if (mapActiveBeacons.find(iClientIDVictim) != mapActiveBeacons.end())
 		{
 			mapActiveBeacons.erase(iClientIDVictim);
@@ -1191,7 +985,7 @@ namespace HyperJump
 			SwitchOut = (PBYTE)hModServer + 0xf600;
 
 			DWORD dummy;
-			VirtualProtect(SwitchOut+0xd7, 200, PAGE_EXECUTE_READWRITE, &dummy);
+			VirtualProtect(SwitchOut + 0xd7, 200, PAGE_EXECUTE_READWRITE, &dummy);
 		}
 
 		// Patch the system switch out routine to put the ship in a
@@ -1201,43 +995,43 @@ namespace HyperJump
 			SwitchOut[0x0d7] = 0xeb;				// ignore exit object
 			SwitchOut[0x0d8] = 0x40;
 			SwitchOut[0x119] = 0xbb;				// set the destination system
-			*(PDWORD)(SwitchOut+0x11a) = mapDeferredJumps[iClientID].system;
+			*(PDWORD)(SwitchOut + 0x11a) = mapDeferredJumps[iClientID].system;
 			SwitchOut[0x266] = 0x45;				// don't generate warning
-			*(float*)(SwitchOut+0x2b0) = mapDeferredJumps[iClientID].pos.z;		// set entry location
-			*(float*)(SwitchOut+0x2b8) = mapDeferredJumps[iClientID].pos.y;
-			*(float*)(SwitchOut+0x2c0) = mapDeferredJumps[iClientID].pos.x;
-			*(float*)(SwitchOut+0x2c8) = mapDeferredJumps[iClientID].ornt.data[2][2];
-			*(float*)(SwitchOut+0x2d0) = mapDeferredJumps[iClientID].ornt.data[1][1];
-			*(float*)(SwitchOut+0x2d8) = mapDeferredJumps[iClientID].ornt.data[0][0];
-			*(float*)(SwitchOut+0x2e0) = mapDeferredJumps[iClientID].ornt.data[2][1];
-			*(float*)(SwitchOut+0x2e8) = mapDeferredJumps[iClientID].ornt.data[2][0];
-			*(float*)(SwitchOut+0x2f0) = mapDeferredJumps[iClientID].ornt.data[1][2];
-			*(float*)(SwitchOut+0x2f8) = mapDeferredJumps[iClientID].ornt.data[1][0];
-			*(float*)(SwitchOut+0x300) = mapDeferredJumps[iClientID].ornt.data[0][2];
-			*(float*)(SwitchOut+0x308) = mapDeferredJumps[iClientID].ornt.data[0][1];
-			*(PDWORD)(SwitchOut+0x388) = 0x03ebc031;		// ignore entry object
+			*(float*)(SwitchOut + 0x2b0) = mapDeferredJumps[iClientID].pos.z;		// set entry location
+			*(float*)(SwitchOut + 0x2b8) = mapDeferredJumps[iClientID].pos.y;
+			*(float*)(SwitchOut + 0x2c0) = mapDeferredJumps[iClientID].pos.x;
+			*(float*)(SwitchOut + 0x2c8) = mapDeferredJumps[iClientID].ornt.data[2][2];
+			*(float*)(SwitchOut + 0x2d0) = mapDeferredJumps[iClientID].ornt.data[1][1];
+			*(float*)(SwitchOut + 0x2d8) = mapDeferredJumps[iClientID].ornt.data[0][0];
+			*(float*)(SwitchOut + 0x2e0) = mapDeferredJumps[iClientID].ornt.data[2][1];
+			*(float*)(SwitchOut + 0x2e8) = mapDeferredJumps[iClientID].ornt.data[2][0];
+			*(float*)(SwitchOut + 0x2f0) = mapDeferredJumps[iClientID].ornt.data[1][2];
+			*(float*)(SwitchOut + 0x2f8) = mapDeferredJumps[iClientID].ornt.data[1][0];
+			*(float*)(SwitchOut + 0x300) = mapDeferredJumps[iClientID].ornt.data[0][2];
+			*(float*)(SwitchOut + 0x308) = mapDeferredJumps[iClientID].ornt.data[0][1];
+			*(PDWORD)(SwitchOut + 0x388) = 0x03ebc031;		// ignore entry object
 			mapDeferredJumps.erase(iClientID);
 			pub::SpaceObj::SetInvincible(iShip, false, false, 0);
-			Server.SystemSwitchOutComplete(iShip,iClientID);
+			Server.SystemSwitchOutComplete(iShip, iClientID);
 			SwitchOut[0x0d7] = 0x0f;
 			SwitchOut[0x0d8] = 0x84;
 			SwitchOut[0x119] = 0x87;
-			*(PDWORD)(SwitchOut+0x11a) = 0x1b8;
-			*(PDWORD)(SwitchOut+0x25d) = 0x1cf7f;
+			*(PDWORD)(SwitchOut + 0x11a) = 0x1b8;
+			*(PDWORD)(SwitchOut + 0x25d) = 0x1cf7f;
 			SwitchOut[0x266] = 0x1a;
-			*(float*)(SwitchOut+0x2b0) =
-				*(float*)(SwitchOut+0x2b8) =
-				*(float*)(SwitchOut+0x2c0) = 0;
-			*(float*)(SwitchOut+0x2c8) =
-				*(float*)(SwitchOut+0x2d0) =
-				*(float*)(SwitchOut+0x2d8) = 1;
-			*(float*)(SwitchOut+0x2e0) =
-				*(float*)(SwitchOut+0x2e8) =
-				*(float*)(SwitchOut+0x2f0) =
-				*(float*)(SwitchOut+0x2f8) =
-				*(float*)(SwitchOut+0x300) =
-				*(float*)(SwitchOut+0x308) = 0;
-			*(PDWORD)(SwitchOut+0x388) = 0xcf8b178b;
+			*(float*)(SwitchOut + 0x2b0) =
+				*(float*)(SwitchOut + 0x2b8) =
+				*(float*)(SwitchOut + 0x2c0) = 0;
+			*(float*)(SwitchOut + 0x2c8) =
+				*(float*)(SwitchOut + 0x2d0) =
+				*(float*)(SwitchOut + 0x2d8) = 1;
+			*(float*)(SwitchOut + 0x2e0) =
+				*(float*)(SwitchOut + 0x2e8) =
+				*(float*)(SwitchOut + 0x2f0) =
+				*(float*)(SwitchOut + 0x2f8) =
+				*(float*)(SwitchOut + 0x300) =
+				*(float*)(SwitchOut + 0x308) = 0;
+			*(PDWORD)(SwitchOut + 0x388) = 0xcf8b178b;
 
 			return true;
 		}
@@ -1246,7 +1040,6 @@ namespace HyperJump
 
 	void HyperJump::ClearClientInfo(uint iClientID)
 	{
-		//mapTestBots.erase(iClientID);
 		mapDeferredJumps.erase(iClientID);
 		mapJumpDrives.erase(iClientID);
 		mapSurvey.erase(iClientID);
@@ -1265,14 +1058,14 @@ namespace HyperJump
 		}
 
 		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false)!=HKE_OK)
+		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK)
 		{
 			cmds->Print(L"ERR Not in space\n");
 			return;
 		}
 
 		HKPLAYERINFO targetPlyr;
-		if (HkGetPlayerInfo(wscCharname, targetPlyr, false)!=HKE_OK || targetPlyr.iShip==0)
+		if (HkGetPlayerInfo(wscCharname, targetPlyr, false) != HKE_OK || targetPlyr.iShip == 0)
 		{
 			cmds->Print(L"ERR Player not found or not in space\n");
 			return;
@@ -1298,13 +1091,13 @@ namespace HyperJump
 		}
 
 		HKPLAYERINFO info;
-		if (HkGetPlayerInfo(wscCharname, info, false)!=HKE_OK)
+		if (HkGetPlayerInfo(wscCharname, info, false) != HKE_OK)
 		{
 			cmds->Print(L"ERR Player not found\n");
 			return true;
 		}
 
-		if (info.iShip==0)
+		if (info.iShip == 0)
 		{
 			cmds->Print(L"ERR Player not in space\n");
 			return true;
@@ -1315,19 +1108,19 @@ namespace HyperJump
 		while (baseinfo)
 		{
 			wstring basename = HkGetWStringFromIDS(baseinfo->iBaseIDS);
-			if (ToLower(basename).find(ToLower(wscTargetBaseName))==0)
+			if (ToLower(basename).find(ToLower(wscTargetBaseName)) == 0)
 			{
 				pub::Player::ForceLand(info.iClientID, baseinfo->iBaseID);
 				if (info.iSystem != baseinfo->iSystemID)
 				{
-					Server.BaseEnter(baseinfo->iBaseID,info.iClientID);
-					Server.BaseExit(baseinfo->iBaseID,info.iClientID);
+					Server.BaseEnter(baseinfo->iBaseID, info.iClientID);
+					Server.BaseExit(baseinfo->iBaseID, info.iClientID);
 					wstring wscCharFileName;
-					HkGetCharFileName(info.wscCharname,wscCharFileName);
+					HkGetCharFileName(info.wscCharname, wscCharFileName);
 					wscCharFileName += L".fl";
 					CHARACTER_ID cID;
-					strcpy(cID.szCharFilename,wstos(wscCharFileName.substr(0,14)).c_str());
-					Server.CharacterSelect(cID, info.iClientID);\
+					strcpy(cID.szCharFilename, wstos(wscCharFileName.substr(0, 14)).c_str());
+					Server.CharacterSelect(cID, info.iClientID); \
 				}
 				return true;
 			}
@@ -1339,19 +1132,19 @@ namespace HyperJump
 		while (baseinfo)
 		{
 			wstring basename = HkGetWStringFromIDS(baseinfo->iBaseIDS);
-			if (ToLower(basename).find(ToLower(wscTargetBaseName))!=-1)
+			if (ToLower(basename).find(ToLower(wscTargetBaseName)) != -1)
 			{
 				pub::Player::ForceLand(info.iClientID, baseinfo->iBaseID);
 				if (info.iSystem != baseinfo->iSystemID)
 				{
-					Server.BaseEnter(baseinfo->iBaseID,info.iClientID);
-					Server.BaseExit(baseinfo->iBaseID,info.iClientID);
+					Server.BaseEnter(baseinfo->iBaseID, info.iClientID);
+					Server.BaseExit(baseinfo->iBaseID, info.iClientID);
 					wstring wscCharFileName;
-					HkGetCharFileName(info.wscCharname,wscCharFileName);
+					HkGetCharFileName(info.wscCharname, wscCharFileName);
 					wscCharFileName += L".fl";
 					CHARACTER_ID cID;
-					strcpy(cID.szCharFilename,wstos(wscCharFileName.substr(0,14)).c_str());
-					Server.CharacterSelect(cID, info.iClientID);\
+					strcpy(cID.szCharFilename, wstos(wscCharFileName.substr(0, 14)).c_str());
+					Server.CharacterSelect(cID, info.iClientID); \
 				}
 				return true;
 			}
@@ -1372,14 +1165,14 @@ namespace HyperJump
 		}
 
 		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false)!=HKE_OK || adminPlyr.iShip==0)
+		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
 		{
 			cmds->Print(L"ERR Not in space\n");
 			return;
 		}
 
 		HKPLAYERINFO targetPlyr;
-		if (HkGetPlayerInfo(wscCharname, targetPlyr, false)!=HKE_OK)
+		if (HkGetPlayerInfo(wscCharname, targetPlyr, false) != HKE_OK)
 		{
 			cmds->Print(L"ERR Player not found\n");
 			return;
@@ -1398,7 +1191,7 @@ namespace HyperJump
 	/** Move to location */
 	void HyperJump::AdminCmd_Move(CCmds* cmds, float x, float y, float z)
 	{
-		if (cmds->ArgStrToEnd(1).length()==0)
+		if (cmds->ArgStrToEnd(1).length() == 0)
 		{
 			cmds->Print(L"ERR Usage: move x y z\n");
 			return;
@@ -1411,7 +1204,7 @@ namespace HyperJump
 		}
 
 		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false)!=HKE_OK || adminPlyr.iShip==0)
+		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
 		{
 			cmds->Print(L"ERR Not in space\n");
 			return;
@@ -1428,99 +1221,10 @@ namespace HyperJump
 		return;
 	}
 
-	/** Start automatic zone checking */
-	/*
-	void HyperJump::AdminCmd_TestBot(CCmds* cmds, const wstring &wscSystemNick, int iCheckZoneTime)
-	{
-		if(!(cmds->rights & RIGHT_SUPERADMIN))
-		{
-			cmds->Print(L"ERR No permission\n");
-			return;
-		}
-
-		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false)!=HKE_OK || adminPlyr.iShip==0)
-		{
-			cmds->Print(L"ERR Not in space\n");
-			return;
-		}
-
-		mapTestBots.erase(adminPlyr.iClientID);
-		if (wscSystemNick == L"stop")
-		{
-			cmds->Print(L"OK Check stopped\n");
-			return;
-		}
-
-		const struct Universe::ISystem *sysinfo = Universe::get_system(CreateID(wstos(wscSystemNick).c_str()));
-		if (sysinfo)
-		{
-			if (iCheckZoneTime==0)
-				iCheckZoneTime = 60;
-
-			TESTBOT tb;
-			tb.bBaseTest = false;
-			tb.iCheckZonesTimer = 0;
-			tb.iCheckSystemOrBase = CreateID(wstos(wscSystemNick).c_str());
-			tb.iCheckTestedZones = 0;
-			tb.iCheckZoneTime = iCheckZoneTime;
-
-			zone_map_iter_t start = zones.lower_bound(tb.iCheckSystemOrBase);
-			zone_map_iter_t end = zones.upper_bound(tb.iCheckSystemOrBase);
-			for (zone_map_iter_t i=start; i!=end; i++)
-			{
-				ZONE rlz;
-				if (ZoneUtilities::InDeathZone(tb.iCheckSystemOrBase, i->second.pos, rlz))
-					continue;
-				if (!i->second.encounter)
-					continue;
-				tb.lstCheckZones.push_back(i->second);
-			}
-
-			cmds->Print(L"Checking system %s (%x) containing %d zones\n", 
-				wscSystemNick.c_str(), tb.iCheckSystemOrBase, tb.lstCheckZones.size());
-
-			// If we're not in the right system then jump to it.
-			if (adminPlyr.iSystem!=tb.iCheckSystemOrBase)
-			{
-				Vector pos = { 0, 100000, 0 };
-				Matrix ornt = { 0 };
-				SwitchSystem(adminPlyr.iClientID, tb.iCheckSystemOrBase, pos, ornt);
-			}
-
-			mapTestBots[adminPlyr.iClientID] = tb;
-			return;
-		}
-
-		const struct Universe::IBase *baseinfo = Universe::get_base(CreateID(wstos(wscSystemNick).c_str()));
-		if (baseinfo)
-		{
-			if (iCheckZoneTime==0)
-				iCheckZoneTime = 15;
-
-			TESTBOT tb;
-			tb.bBaseTest = true;
-			tb.iCheckZonesTimer = 0;
-			tb.iCheckSystemOrBase = CreateID(wstos(wscSystemNick).c_str());
-			tb.iCheckTestedZones = 0;
-			tb.iCheckZoneTime = iCheckZoneTime;
-
-			cmds->Print(L"Testing base %s (%x) containing\n", 
-				wscSystemNick.c_str(), tb.iCheckSystemOrBase);
-			
-			mapTestBots[adminPlyr.iClientID] = tb;
-			return;
-		}
-		
-		cmds->Print(L"ERR System or base not found\n");
-		return;
-	}
-	*/
-
 	bool InitJumpDriveInfo(uint iClientID)
 	{
 		// Initialise the drive parameters for this ship
-		if (mapJumpDrives.find(iClientID)==mapJumpDrives.end())
+		if (mapJumpDrives.find(iClientID) == mapJumpDrives.end())
 		{
 			mapJumpDrives[iClientID].arch.nickname = 0;
 			mapJumpDrives[iClientID].arch.can_jump_charge = 0;
@@ -1581,7 +1285,7 @@ namespace HyperJump
 	bool InitSurveyInfo(uint iClientID)
 	{
 		// Initialise the drive parameters for this ship
-		if (mapSurvey.find(iClientID)==mapSurvey.end())
+		if (mapSurvey.find(iClientID) == mapSurvey.end())
 		{
 			mapSurvey[iClientID].arch.nickname = 0;
 			mapSurvey[iClientID].arch.survey_complete_charge = 0;
@@ -1592,7 +1296,7 @@ namespace HyperJump
 
 			mapSurvey[iClientID].charging_on = false;
 			mapSurvey[iClientID].curr_charge = 0;
-			
+
 			// Check that the player has a jump drive and initialise the infomation
 			// about it - otherwise return false.
 			for (list<EquipDesc>::iterator item = Players[iClientID].equipDescList.equip.begin(); item != Players[iClientID].equipDescList.equip.end(); item++)
@@ -1622,7 +1326,7 @@ namespace HyperJump
 
 		if (!InitSurveyInfo(iClientID))
 		{
-			PrintUserCmdText(iClientID, L"Survey module not available");			
+			PrintUserCmdText(iClientID, L"Survey module not available");
 			return true;
 		}
 
@@ -1631,12 +1335,12 @@ namespace HyperJump
 		CShip* cship = (CShip*)HkGetEqObjFromObjRW((IObjRW*)obj);
 		if (cship->get_max_power() < sm.arch.power)
 		{
-			PrintUserCmdText(iClientID, L"Insufficient power to start survey module");			
+			PrintUserCmdText(iClientID, L"Insufficient power to start survey module");
 			return true;
 		}
 
 		HKPLAYERINFO p;
-		if (HkGetPlayerInfo((const wchar_t*) Players.GetActiveCharacterName(iClientID), p, false)!=HKE_OK || p.iShip==0)
+		if (HkGetPlayerInfo((const wchar_t*)Players.GetActiveCharacterName(iClientID), p, false) != HKE_OK || p.iShip == 0)
 		{
 			PrintUserCmdText(iClientID, L"ERR Not in space");
 			return true;
@@ -1657,13 +1361,13 @@ namespace HyperJump
 		sm.charging_on = !sm.charging_on;
 		if (sm.charging_on)
 		{
-			PrintUserCmdText(iClientID, L"Survey started");			
+			PrintUserCmdText(iClientID, L"Survey started");
 			sm.curr_charge = 0;
 			return true;
 		}
 		else
 		{
-			PrintUserCmdText(iClientID, L"Survey aborted");			
+			PrintUserCmdText(iClientID, L"Survey aborted");
 			sm.curr_charge = 0;
 			return true;
 		}
@@ -1673,26 +1377,12 @@ namespace HyperJump
 	{
 		if (!InitJumpDriveInfo(iClientID))
 		{
-			PrintUserCmdText(iClientID, L"Jump drive not available");			
+			PrintUserCmdText(iClientID, L"Jump drive not available");
 			return true;
 		}
 
 		JUMPDRIVE &jd = mapJumpDrives[iClientID];
 		jd.iTargetSystem = 0;
-
-	//code to catch assholes	
-		if (jd.jump_timer > 0)
-		{
-			jd.rekt = true;
-			wstring wscCharname = (const wchar_t*) Players.GetActiveCharacterName(iClientID);
-			wstring wscMsgU = L"%name has been permabanned. (Type 5)";
-			wscMsgU = ReplaceStr(wscMsgU, L"%name", wscCharname.c_str());
-			HkMsgU(wscMsgU);
-
-			LogCheater(iClientID, wscMsgU);
-			return true;
-		}
-		
 
 		string sbuf = wstos(ReplaceStr(GetParam(wscParam, L' ', 0), L"-", L""));
 		if (sbuf.size() != 56)
@@ -1702,15 +1392,15 @@ namespace HyperJump
 		}
 
 		char ibuf[HCOORD_SIZE];
-		for (uint i=0, p=0; i<HCOORD_SIZE && (p+1)<sbuf.size(); i++, p+=2)
+		for (uint i = 0, p = 0; i < HCOORD_SIZE && (p + 1) < sbuf.size(); i++, p += 2)
 		{
 			char buf[3];
 			buf[0] = sbuf[p];
-			buf[1] = sbuf[p+1];
+			buf[1] = sbuf[p + 1];
 			buf[2] = 0;
 			ibuf[i] = (char)strtoul(buf, 0, 16);
 		}
-		
+
 		HYPERSPACE_COORDS coords;
 		char* obuf = (char*)&coords;
 		memset(&coords, 0, sizeof(coords));
@@ -1719,7 +1409,7 @@ namespace HyperJump
 
 		// Calculate a simple parity check
 		WORD parity = 0;
-		for (int i=2; i<HCOORD_SIZE; i++)
+		for (int i = 2; i < HCOORD_SIZE; i++)
 			parity += obuf[i];
 
 		if (coords.parity != parity)
@@ -1727,13 +1417,27 @@ namespace HyperJump
 			PrintUserCmdText(iClientID, L"ERR Invalid coordinates, parity error");
 			return true;
 		}
-	
+
+		////////////////////////// System limit restriction ///////////////////////////////////////
+		if (JumpSystemListEnabled == 1)
+		{
+			bool AllowedToWhiteListJump = IsSystemJumpable(Players[iClientID].iSystemID, coords.system);
+			if (AllowedToWhiteListJump == 0)
+			{
+				const Universe::ISystem *iSysList = Universe::get_system(coords.system);
+				wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
+				PrintUserCmdText(iClientID, L"ERROR: Gravitational rift detected. Cannot jump to %s from this system.", wscSysNameList.c_str());
+				return true;
+			}
+		}
+		////////////////////////// End of System limit restriction ///////////////////////////////////////
+
 		if (coords.time < time(0))
 		{
 			PrintUserCmdText(iClientID, L"Warning old coordinates detected. Jump not recommended");
-			coords.accuracy *= rand()%6 + 1;
+			coords.accuracy *= rand() % 6 + 1;
 		}
-		
+
 		jd.iTargetSystem = coords.system;
 		jd.vTargetPosition.x = coords.x;
 		jd.vTargetPosition.y = coords.y;
@@ -1747,9 +1451,9 @@ namespace HyperJump
 			*(float*)&jd.vTargetPosition.z);
 
 		int wiggle_factor = (int)coords.accuracy;
-		jd.vTargetPosition.x += ((rand()*10) % wiggle_factor) - (wiggle_factor/2);
-		jd.vTargetPosition.y += ((rand()*10) % wiggle_factor) - (wiggle_factor/2);
-		jd.vTargetPosition.z += ((rand()*10) % wiggle_factor) - (wiggle_factor/2);
+		jd.vTargetPosition.x += ((rand() * 10) % wiggle_factor) - (wiggle_factor / 2);
+		jd.vTargetPosition.y += ((rand() * 10) % wiggle_factor) - (wiggle_factor / 2);
+		jd.vTargetPosition.z += ((rand() * 10) % wiggle_factor) - (wiggle_factor / 2);
 
 		return true;
 	}
@@ -1760,14 +1464,14 @@ namespace HyperJump
 		IObjInspectImpl *obj = HkGetInspect(iClientID);
 		if (!obj)
 		{
-			PrintUserCmdText(iClientID, L"Jump drive charging failed");			
+			PrintUserCmdText(iClientID, L"Jump drive charging failed");
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 			return true;
 		}
 
 		if (!InitJumpDriveInfo(iClientID))
 		{
-			PrintUserCmdText(iClientID, L"Jump drive not available");			
+			PrintUserCmdText(iClientID, L"Jump drive not available");
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 			return true;
 		}
@@ -1777,17 +1481,16 @@ namespace HyperJump
 		CShip* cship = (CShip*)HkGetEqObjFromObjRW((IObjRW*)obj);
 		if (cship->get_max_power() < jd.arch.power)
 		{
-			PrintUserCmdText(iClientID, L"Insufficient power to charge jumpdrive");			
+			PrintUserCmdText(iClientID, L"Insufficient power to charge jumpdrive");
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 			return true;
 		}
-		
+
 		// Toogle the charge state
 		jd.charging_on = !jd.charging_on;
 		jd.charge_status = -1;
 
 		uint iSystemID;
-		uint AllowedToWhiteListJump = 0;
 		pub::Player::GetSystem(iClientID, iSystemID);
 
 		// Start the jump effect
@@ -1795,59 +1498,28 @@ namespace HyperJump
 		{
 			if (jd.iTargetSystem == 0)
 			{
-				PrintUserCmdText(iClientID, L"WARNING NO JUMP COORDINATES");			
+				PrintUserCmdText(iClientID, L"WARNING NO JUMP COORDINATES");
 				pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_blind_jump_warning"));
 			}
-		////////////////////////// System limit restriction ///////////////////////////////////////
-		if (JumpSystemListEnabled == 1 && jd.iTargetSystem != 0)
-		{
-			const Universe::ISystem *iSys = Universe::get_system(iSystemID);
-		    wstring wscSysName = HkGetWStringFromIDS(iSys->strid_name);
-			//PrintUserCmdText(iClientID, L"Space kitteh knows you are in %u !", iSystemID);
-			for (map<uint, SYSTEM_JUMPLIST>::iterator iter = mapJumpSystems.begin(); iter!=mapJumpSystems.end(); iter++)
+			////////////////////////// System limit restriction ///////////////////////////////////////
+			else if (JumpSystemListEnabled == 1 && jd.iTargetSystem != 0)
 			{
-			
-			SYSTEM_JUMPLIST &jumpsyslist = iter->second;
-				if (jumpsyslist.nickname == iSystemID) 
+				bool AllowedToWhiteListJump = IsSystemJumpable(iSystemID, jd.iTargetSystem);
+				if (AllowedToWhiteListJump == 0)
 				{
-				//PrintUserCmdText(iClientID, L"The script has found %u !", iSystemID);
-			
-					for (map<uint, uint>::iterator i = jumpsyslist.mapSystemsList.begin(); i != jumpsyslist.mapSystemsList.end(); ++i) 
-					{
-						if ( jd.iTargetSystem == i->first)
-						{
-							const Universe::ISystem *iSysList = Universe::get_system(i->first);
-							wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
-							//PrintUserCmdText(iClientID, L"Space kitteh knows you are attempting to jump to %s. Space kitteh agrees with that choice.", wscSysNameList.c_str() );
-							AllowedToWhiteListJump = 1;
-						}
-					}
-					if (jd.iTargetSystem == 0)
-					{
-					//PrintUserCmdText(iClientID, L"Space kitteh thinks u crazy !!! Blind jump is dangerous !");
-					}
-					if (AllowedToWhiteListJump == 0)
-					{
-							const Universe::ISystem *iSysList = Universe::get_system(jd.iTargetSystem);
-							wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
-							PrintUserCmdText(iClientID, L"ERROR: Gravitational rift detected. Cannot jump to %s from this system.", wscSysNameList.c_str() );
-							PrintUserCmdText(iClientID, L"Jump drive disabled. Use /jumpsys for the list of available systems.");
-							jd.charging_complete = false;
-							jd.curr_charge = 0.0;
-							jd.charging_on = false;
-							StopChargeFuses(iClientID);
-							return true;
-					}
-					
+					const Universe::ISystem *iSysList = Universe::get_system(jd.iTargetSystem);
+					wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
+					PrintUserCmdText(iClientID, L"ERROR: Gravitational rift detected. Cannot jump to %s from this system.", wscSysNameList.c_str());
+					PrintUserCmdText(iClientID, L"Jump drive disabled. Use /jumpsys for the list of available systems.");
+					jd.charging_complete = false;
+					jd.curr_charge = 0.0;
+					jd.charging_on = false;
+					StopChargeFuses(iClientID);
+					return true;
 				}
 			}
-		}
-		else
-		{
-			//PrintUserCmdText(iClientID, L"Jump Whitelisting is not enabled. Carry on!");	
-		}
-		////////////////////////// End of System limit restriction ///////////////////////////////////////
-			
+			////////////////////////// End of System limit restriction ///////////////////////////////////////
+
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging"));
 			PrintUserCmdText(iClientID, L"Jump drive charging");
 			// Print out a message within the iLocalChatRange when a player engages a JD.
@@ -1863,7 +1535,6 @@ namespace HyperJump
 			StopChargeFuses(iClientID);
 			SetFuse(iClientID, 0);
 		}
-		AllowedToWhiteListJump = 0;
 		return true;
 	}
 
@@ -1873,7 +1544,7 @@ namespace HyperJump
 		IObjInspectImpl *obj = HkGetInspect(iClientID);
 		if (!obj)
 		{
-			PrintUserCmdText(iClientID, L"Jump drive charging failed");			
+			PrintUserCmdText(iClientID, L"Jump drive charging failed");
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 			return true;
 		}
@@ -1881,17 +1552,17 @@ namespace HyperJump
 		// If no jumpdrive, report a warning.
 		if (!InitJumpDriveInfo(iClientID))
 		{
-			PrintUserCmdText(iClientID, L"Jump drive not ready");			
+			PrintUserCmdText(iClientID, L"Jump drive not ready");
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 			return true;
 		}
-		
+
 		JUMPDRIVE &jd = mapJumpDrives[iClientID];
 
 		// If insufficient charging, report a warning
 		if (!jd.charging_complete)
 		{
-			PrintUserCmdText(iClientID, L"Jump drive not ready");			
+			PrintUserCmdText(iClientID, L"Jump drive not ready");
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_not_ready"));
 			return true;
 		}
@@ -1903,25 +1574,39 @@ namespace HyperJump
 
 			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_blind_jump_warning"));
 
-			vector<string> systems;
-			struct Universe::ISystem *sysinfo = Universe::GetFirstSystem();
-			while (sysinfo)
+			if (!JumpSystemListEnabled)
 			{
-				systems.push_back(sysinfo->nickname);
-				sysinfo = Universe::GetNextSystem();
-			}
-			bool isBannedSystem = true;
-			while(isBannedSystem)
-			{
+				vector<string> systems;
+				struct Universe::ISystem *sysinfo = Universe::GetFirstSystem();
+				while (sysinfo)
+				{
+					systems.push_back(sysinfo->nickname);
+					sysinfo = Universe::GetNextSystem();
+				}
 				// Pick a random system and position
 				jd.iTargetSystem = CreateID(systems[rand() % systems.size()].c_str());
-				if (set_banned_systems.find(jd.iTargetSystem) != set_banned_systems.end())
-				{
-					PrintUserCmdText(iClientID, L"ERR: Hyper Drive Malfunction. Recalculating Jump.");
-					continue;
-				}
-				isBannedSystem = false;
 			}
+			else
+			{
+				auto systemListIter = mapJumpSystems.find(Players[iClientID].iSystemID);
+				if (systemListIter != mapJumpSystems.end())
+				{
+					auto &systemList = systemListIter->second.visibleSystemsList;
+					if (!systemList.empty())
+					{
+						jd.iTargetSystem = systemList.at(rand() % systemList.size());
+					}
+				}
+
+				// If can't jump - notify.
+				if (jd.iTargetSystem == 0)
+				{
+					PrintUserCmdText(iClientID, L"Jump drive malfunction. Cannot jump from the system.");
+					pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
+					return true;
+				}
+			}
+
 			jd.vTargetPosition.x = ((rand() * 10) % 400000) - 200000.0f;
 			jd.vTargetPosition.y = ((rand() * 10) % 400000) - 200000.0f;
 			jd.vTargetPosition.z = ((rand() * 10) % 400000) - 200000.0f;
@@ -1933,37 +1618,12 @@ namespace HyperJump
 		return true;
 	}
 
-	/** Move to location */
-	void HyperJump::AdminCmd_JumpTest(CCmds* cmds, const wstring &sys)
-	{
-		if (!(cmds->rights & RIGHT_SUPERADMIN))
-		{
-			cmds->Print(L"ERR No permission\n");
-			return;
-		}
-
-		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false)!=HKE_OK || adminPlyr.iShip==0)
-		{
-			cmds->Print(L"ERR Not in space\n");
-			return;
-		}
-
-		JUMPDRIVE &jd = mapJumpDrives[adminPlyr.iClientID];
-
-		jd.iTargetSystem = CreateID(wstos(sys).c_str());
-		jd.vTargetPosition.x = ((rand()*10) % 400000) - 200000.0f;
-		jd.vTargetPosition.y = ((rand()*10) % 400000) - 200000.0f;
-		jd.vTargetPosition.z = ((rand()*10) % 400000) - 200000.0f;
-		jd.jump_timer = 8;
-		return;
-	}
-
-	time_t filetime_to_timet(const FILETIME& ft){
+	time_t filetime_to_timet(const FILETIME& ft) {
 		ULARGE_INTEGER ull;
 		ull.LowPart = ft.dwLowDateTime;
 		ull.HighPart = ft.dwHighDateTime;
-		return ull.QuadPart / 10000000ULL - 11644473600ULL;}
+		return ull.QuadPart / 10000000ULL - 11644473600ULL;
+	}
 
 	// Move the ship's starting position randomly if it has been logged out in space.
 	void HyperJump::PlayerLaunch(unsigned int iShip, unsigned int iClientID)
@@ -1975,7 +1635,7 @@ namespace HyperJump
 		if (HkFLIniGet((const wchar_t*)Players.GetActiveCharacterName(iClientID), L"tstamp", wscTimeStamp) != HKE_OK)
 			return;
 
-		FILETIME ft; 
+		FILETIME ft;
 		ft.dwHighDateTime = strtoul(GetParam(wstos(wscTimeStamp), ',', 0).c_str(), 0, 10);
 		ft.dwLowDateTime = strtoul(GetParam(wstos(wscTimeStamp), ',', 1).c_str(), 0, 10);
 		time_t lastTime = filetime_to_timet(ft);
@@ -1993,9 +1653,7 @@ namespace HyperJump
 		if (drift > MAX_DRIFT)
 			drift = MAX_DRIFT;
 
-		drift *= ( (2.0f * rand() / (float)RAND_MAX) - 1.0f);
-		//if (wscRights.size())
-		//	ConPrint(L"drift=%0.0f currTime=%u lastTime=%u\n", drift, (uint)currTime, (uint)lastTime);
+		drift *= ((2.0f * rand() / (float)RAND_MAX) - 1.0f);
 
 		// Adjust the ship's position.
 		Vector pos = { Players[iClientID].vPosition.x, Players[iClientID].vPosition.y, Players[iClientID].vPosition.z };
@@ -2014,7 +1672,7 @@ namespace HyperJump
 				mapSurvey[iClientID].curr_charge = 0;
 				mapSurvey[iClientID].charging_on = false;
 				PrintUserCmdText(iClientID, L"Hyperspace survey disrupted, restart required");
-			}			
+			}
 		}
 
 		//TEMPORARY: Allow JDs to be disrupted with CDs
@@ -2023,13 +1681,12 @@ namespace HyperJump
 			if (mapJumpDrives[iClientID].charging_on && mapJumpDrives[iClientID].arch.cd_disrupts_charge)
 			{
 				if (dmg->get_cause() == 6)
-				{				
-				mapJumpDrives[iClientID].charging_on = false;
-				PrintUserCmdText(iClientID, L"Jump drive disrupted. Charging failed.");
-				//PrintUserCmdText(iClientID, L"Jump drive disruption successful");
-				pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
-				SetFuse(iClientID, 0);
-				StopChargeFuses(iClientID);
+				{
+					mapJumpDrives[iClientID].charging_on = false;
+					PrintUserCmdText(iClientID, L"Jump drive disrupted. Charging failed.");
+					pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
+					SetFuse(iClientID, 0);
+					StopChargeFuses(iClientID);
 				}
 			}
 		}
@@ -2037,9 +1694,8 @@ namespace HyperJump
 
 	bool HyperJump::UserCmd_DeployBeacon(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
 	{
-		
 		HKPLAYERINFO p;
-		if (HkGetPlayerInfo((const wchar_t*) Players.GetActiveCharacterName(iClientID), p, false)!=HKE_OK || p.iShip==0)
+		if (HkGetPlayerInfo((const wchar_t*)Players.GetActiveCharacterName(iClientID), p, false) != HKE_OK || p.iShip == 0)
 		{
 			PrintUserCmdText(iClientID, L"ERR Not in space");
 			return true;
@@ -2051,7 +1707,7 @@ namespace HyperJump
 			return true;
 		}
 
-		for (map<uint, BEACONTIMER>::iterator i = mapActiveBeacons.begin(); i != mapActiveBeacons.end(); ++i) 
+		for (map<uint, BEACONTIMER>::iterator i = mapActiveBeacons.begin(); i != mapActiveBeacons.end(); ++i)
 		{
 			if (i->first == iClientID)
 			{
@@ -2087,7 +1743,7 @@ namespace HyperJump
 				{
 					HkLightFuse((IObjRW*)obj, BeaconFuse, 0, BeaconTime, 0);
 				}
-				
+
 				BEACONTIMER bc;
 				bc.cooldown = BeaconCooldown;
 				bc.timeleft = BeaconTime;
@@ -2105,7 +1761,6 @@ namespace HyperJump
 
 	bool HyperJump::UserCmd_JumpBeacon(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
 	{
-		HK_ERROR err;
 		// Indicate an error if the command does not appear to be formatted correctly 
 		// and stop processing but tell FLHook that we processed the command.
 		if (wscParam.size() == 0)
@@ -2172,9 +1827,8 @@ namespace HyperJump
 
 			uint iShipTarget;
 			pub::Player::GetShip(iClientIDTarget, iShipTarget);
-				
+
 			uint iSystemID;
-			uint AllowedToWhiteListJump = 0;
 			pub::Player::GetSystem(iClientID, iSystemID);
 
 			uint iTargetSystem;
@@ -2184,49 +1838,22 @@ namespace HyperJump
 			pub::Player::GetSystem(iClientIDTarget, iTargetSystem);
 
 
-
 			////////////////////////// System limit restriction ///////////////////////////////////////
 			if (JumpSystemListEnabled == 1)
 			{
-				const Universe::ISystem *iSys = Universe::get_system(iSystemID);
-				wstring wscSysName = HkGetWStringFromIDS(iSys->strid_name);
-				//PrintUserCmdText(iClientID, L"Space kitteh knows you are in %u !", iSystemID);
-				for (map<uint, SYSTEM_JUMPLIST>::iterator iter = mapJumpSystems.begin(); iter != mapJumpSystems.end(); iter++)
+				bool AllowedToWhiteListJump = IsSystemJumpable(iSystemID, iTargetSystem);
+				if (AllowedToWhiteListJump == 0)
 				{
-
-					SYSTEM_JUMPLIST &jumpsyslist = iter->second;
-					if (jumpsyslist.nickname == iSystemID)
-					{
-						//PrintUserCmdText(iClientID, L"The script has found %u !", iSystemID);
-
-						for (map<uint, uint>::iterator i = jumpsyslist.mapSystemsList.begin(); i != jumpsyslist.mapSystemsList.end(); ++i)
-						{
-							if (iTargetSystem == i->first)
-							{
-								const Universe::ISystem *iSysList = Universe::get_system(i->first);
-								wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
-								//PrintUserCmdText(iClientID, L"Space kitteh knows you are attempting to jump to %s. Space kitteh agrees with that choice.", wscSysNameList.c_str() );
-								AllowedToWhiteListJump = 1;
-							}
-						}
-						if (AllowedToWhiteListJump == 0)
-						{
-							const Universe::ISystem *iSysList = Universe::get_system(jd.iTargetSystem);
-							wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
-							PrintUserCmdText(iClientID, L"ERROR: Gravitational rift detected. Cannot jump to %s from this system.", wscSysNameList.c_str());
-							PrintUserCmdText(iClientID, L"Jump drive disabled. Use /jumpsys for the list of available systems.");
-							jd.charging_complete = false;
-							jd.curr_charge = 0.0;
-							jd.charging_on = false;
-							StopChargeFuses(iClientID);
-							return true;
-						}
-					}
+					const Universe::ISystem *iSysList = Universe::get_system(jd.iTargetSystem);
+					wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
+					PrintUserCmdText(iClientID, L"ERROR: Gravitational rift detected. Cannot jump to %s from this system.", wscSysNameList.c_str());
+					PrintUserCmdText(iClientID, L"Jump drive disabled. Use /jumpsys for the list of available systems.");
+					jd.charging_complete = false;
+					jd.curr_charge = 0.0;
+					jd.charging_on = false;
+					StopChargeFuses(iClientID);
+					return true;
 				}
-			}
-			else
-			{
-				//PrintUserCmdText(iClientID, L"Jump Whitelisting is not enabled. Carry on!");	
 			}
 			////////////////////////// End of System limit restriction ///////////////////////////////////////
 
@@ -2273,7 +1900,7 @@ namespace HyperJump
 				pub::Player::SendNNMessage(iTargetID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 				SetFuse(iTargetID, 0);
 				StopChargeFuses(iTargetID);
-			}			
+			}
 		}
 	}
 

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -56,11 +56,7 @@ namespace HyperJump
 		}
 	}
 
-	struct SYSTEM_JUMPLIST
-	{
-		vector<uint> visibleSystemsList;
-	};
-	static map<uint, SYSTEM_JUMPLIST> mapJumpSystems;
+	static map<uint, vector<uint>> mapJumpSystems;
 
 	static int JumpWhiteListEnabled = 0;
 	static int JumpSystemListEnabled = 0;
@@ -403,7 +399,7 @@ namespace HyperJump
 				if (ini.is_header("system"))
 				{
 					uint nickname;
-					SYSTEM_JUMPLIST jumpsyslist;
+					vector<uint> visibleSystemsList;
 					while (ini.read_value())
 					{
 						if (ini.is_value("nickname"))
@@ -412,10 +408,10 @@ namespace HyperJump
 						}
 						else if (ini.is_value("jump"))
 						{
-							jumpsyslist.visibleSystemsList.push_back(CreateID(ini.get_value_string(0)));
+							visibleSystemsList.push_back(CreateID(ini.get_value_string(0)));
 						}
 					}
-					mapJumpSystems[nickname] = jumpsyslist;
+					mapJumpSystems[nickname] = visibleSystemsList;
 				}
 			}
 			ini.close();
@@ -487,9 +483,9 @@ namespace HyperJump
 
 		if (JumpWhiteListEnabled == 1)
 		{
-			for (map<uint, SYSTEM_JUMPLIST>::iterator iter = mapJumpSystems.begin(); iter!=mapJumpSystems.end(); iter++)
+			for (map<uint, vector<uint>>::iterator iter = mapJumpSystems.begin(); iter!=mapJumpSystems.end(); iter++)
 			{
-				vector<uint> &systemList = iter->second.visibleSystemsList;
+				vector<uint> &systemList = iter->second;
 				if (iter->first == iSystemID)
 				{
 					PrintUserCmdText(iClientID, L"The script has found %s !", wscSysName.c_str());
@@ -518,7 +514,7 @@ namespace HyperJump
 		if (allowedSystemIter == mapJumpSystems.end())
 			return false;
 
-		vector<uint> &allowedSystems = allowedSystemIter->second.visibleSystemsList;
+		vector<uint> &allowedSystems = allowedSystemIter->second;
 		return find(allowedSystems.begin(), allowedSystems.end(), systemTo) != allowedSystems.end();
 	}
 
@@ -1597,7 +1593,7 @@ namespace HyperJump
 				auto systemListIter = mapJumpSystems.find(Players[iClientID].iSystemID);
 				if (systemListIter != mapJumpSystems.end())
 				{
-					auto &systemList = systemListIter->second.visibleSystemsList;
+					auto &systemList = systemListIter->second;
 					if (!systemList.empty())
 					{
 						jd.iTargetSystem = systemList.at(rand() % systemList.size());

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -1421,10 +1421,10 @@ namespace HyperJump
 		}
 
 		////////////////////////// System limit restriction ///////////////////////////////////////
-		if (JumpSystemListEnabled == 1)
+		if (JumpSystemListEnabled)
 		{
 			bool AllowedToWhiteListJump = IsSystemJumpable(Players[iClientID].iSystemID, coords.system);
-			if (AllowedToWhiteListJump == 0)
+			if (!AllowedToWhiteListJump)
 			{
 				const Universe::ISystem *iSysList = Universe::get_system(coords.system);
 				wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
@@ -1504,10 +1504,10 @@ namespace HyperJump
 				pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_blind_jump_warning"));
 			}
 			////////////////////////// System limit restriction ///////////////////////////////////////
-			else if (JumpSystemListEnabled == 1 && jd.iTargetSystem != 0)
+			else if (JumpSystemListEnabled)
 			{
 				bool AllowedToWhiteListJump = IsSystemJumpable(iSystemID, jd.iTargetSystem);
-				if (AllowedToWhiteListJump == 0)
+				if (!AllowedToWhiteListJump)
 				{
 					const Universe::ISystem *iSysList = Universe::get_system(jd.iTargetSystem);
 					wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);
@@ -1844,7 +1844,7 @@ namespace HyperJump
 			if (JumpSystemListEnabled == 1)
 			{
 				bool AllowedToWhiteListJump = IsSystemJumpable(iSystemID, iTargetSystem);
-				if (AllowedToWhiteListJump == 0)
+				if (!AllowedToWhiteListJump)
 				{
 					const Universe::ISystem *iSysList = Universe::get_system(jd.iTargetSystem);
 					wstring wscSysNameList = HkGetWStringFromIDS(iSysList->strid_name);

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -1579,11 +1579,9 @@ namespace HyperJump
 			if (!JumpSystemListEnabled)
 			{
 				vector<string> systems;
-				struct Universe::ISystem *sysinfo = Universe::GetFirstSystem();
-				while (sysinfo)
+				for (struct Universe::ISystem *sysinfo = Universe::GetFirstSystem(); sysinfo; sysinfo = Universe::GetNextSystem())
 				{
 					systems.push_back(sysinfo->nickname);
-					sysinfo = Universe::GetNextSystem();
 				}
 				// Pick a random system and position
 				jd.iTargetSystem = CreateID(systems[rand() % systems.size()].c_str());

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -188,7 +188,7 @@ namespace HyperJump
 		{
 			if (p > set_scEncryptKey.length())
 				p = 0;
-			obuf[i] = ibuf[i] ^ set_scEncryptKey[p];
+			obuf[i] = ibuf[i]^set_scEncryptKey[p];
 		}
 	}
 
@@ -221,7 +221,7 @@ namespace HyperJump
 		GetCurrentDirectory(sizeof(szCurDir), szCurDir);
 		string scCfgFile = string(szCurDir) + "\\flhook_plugins\\jump.cfg";
 		string scCfgFileSystemList = string(szCurDir) + "\\flhook_plugins\\jump_allowedsystems.cfg";
-			
+
 		int iItemID = 1;
 
 		INI_Reader ini;
@@ -484,7 +484,7 @@ namespace HyperJump
 		wstring wscSysName = HkGetWStringFromIDS(iSys->strid_name);
 
 		PrintUserCmdText(iClientID, L"Space kitteh knows you are in %s !", wscSysName.c_str());
-				
+
 		if (JumpWhiteListEnabled == 1)
 		{
 			for (map<uint, SYSTEM_JUMPLIST>::iterator iter = mapJumpSystems.begin(); iter!=mapJumpSystems.end(); iter++)
@@ -629,7 +629,7 @@ namespace HyperJump
 		for (map<uint, SURVEY>::iterator iter = mapSurvey.begin(); iter!=mapSurvey.end(); iter++)
 		{
 			uint iClientID = iter->first;
-						
+
 			uint iShip;
 			pub::Player::GetShip(iClientID, iShip);
 			if (iShip==0)
@@ -728,7 +728,7 @@ namespace HyperJump
 		for (map<uint, JUMPDRIVE>::iterator iter = mapJumpDrives.begin(); iter!=mapJumpDrives.end(); iter++)
 		{
 			uint iClientID = iter->first;
-						
+
 			uint iShip;
 			pub::Player::GetShip(iClientID, iShip);
 			if (iShip==0)
@@ -927,7 +927,7 @@ namespace HyperJump
 					{
 						jd.charge_status = expected_charge_status;
 						PrintUserCmdText(iClientID, L"Jump drive charge %0.0f%%", (jd.curr_charge/jd.arch.can_jump_charge)*100.0f);
-												
+
 						// Find the currently expected charge fuse
 						uint charge_fuse_idx = (uint)((jd.curr_charge/jd.arch.can_jump_charge) * (jd.arch.charge_fuse.size() - 1));
 						if (charge_fuse_idx >= jd.arch.charge_fuse.size())
@@ -1496,7 +1496,7 @@ namespace HyperJump
 		{
 			if (jd.iTargetSystem == 0)
 			{
-				PrintUserCmdText(iClientID, L"WARNING NO JUMP COORDINATES");
+				PrintUserCmdText(iClientID, L"WARNING NO JUMP COORDINATES");			
 				pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_blind_jump_warning"));
 			}
 			////////////////////////// System limit restriction ///////////////////////////////////////

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -1379,7 +1379,15 @@ namespace HyperJump
 			return true;
 		}
 
+
 		JUMPDRIVE &jd = mapJumpDrives[iClientID];
+
+		if (jd.jump_timer)
+		{
+			PrintUserCmdText(iClientID, L"Unable to change coordinates during jump.");
+			return true;
+		}
+
 		jd.iTargetSystem = 0;
 
 		string sbuf = wstos(ReplaceStr(GetParam(wscParam, L' ', 0), L"-", L""));

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -1407,14 +1407,6 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 		HyperJump::AdminCmd_Chase(cmds, cmds->ArgCharname(1));
 		return true;
 	}
-	/*
-	else if (IS_CMD("testbot"))
-	{
-		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
-		HyperJump::AdminCmd_TestBot(cmds, cmds->ArgStr(1), cmds->ArgInt(2));
-		return true;
-	}
-	*/
 	else if (IS_CMD("lrs"))
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
@@ -1427,13 +1419,6 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 		HyperJump::AdminCmd_MakeCoord(cmds);
 		return true;
 	}
-	else if (IS_CMD("jumptest"))
-	{
-		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
-		HyperJump::AdminCmd_JumpTest(cmds, cmds->ArgStr(1));
-		return true;
-	}
-	
 	else if (IS_CMD("authchar"))
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;


### PR DESCRIPTION
1. Removed:
 a. Commented out code.
 b. Death and banned systems.
 c. Detection of macro users (code to catch assholes) as it may ban users who just use Ctrl + ↑ to quickly pull coordinates from chat history.
 d. .testjump command
2. Added:
 a. System whitelist checks at blind jumps and /setcoords command.
 b. Inability to use /setcoords while jumping.