### PR TITLE
FLHook, base: Add POB module query IPC, fabrication module

### DIFF
--- a/Plugins/Public/base_plugin/Base Plugin.vc14.vcxproj
+++ b/Plugins/Public/base_plugin/Base Plugin.vc14.vcxproj
@@ -138,6 +138,7 @@ copy /Y $(OutDir)$(TargetName).pdb  ..\..\..\Binaries\bin-vc14\flhook_plugins\pu
     <ClCompile Include="CoreModule.cpp" />
     <ClCompile Include="DefenseModule.cpp" />
     <ClCompile Include="ExportData.cpp" />
+    <ClCompile Include="FabricatorModule.cpp" />
     <ClCompile Include="FactoryModule.cpp" />
     <ClCompile Include="Jumper.cpp" />
     <ClCompile Include="Logs.cpp" />

--- a/Plugins/Public/base_plugin/BuildModule.cpp
+++ b/Plugins/Public/base_plugin/BuildModule.cpp
@@ -3,7 +3,7 @@
 const char* MODULE_TYPE_NICKNAMES[] =
 { "module_build", "module_coreupgrade", "module_shieldgen",
 	"module_storage", "module_defense_1", "module_m_docking", "module_m_jumpdrives",
-	"module_m_hyperspace_scanner", "module_m_cloak", "module_defense_2", "module_defense_3", "module_m_cloakdisruptor", 0 };
+	"module_m_hyperspace_scanner", "module_m_cloak", "module_defense_2", "module_defense_3", "module_m_cloakdisruptor", "module_fabricator", 0 };
 
 BuildModule::BuildModule(PlayerBase *the_base)
 	: Module(TYPE_BUILD), base(the_base), build_type(0)
@@ -147,6 +147,9 @@ bool BuildModule::Timer(uint time)
 					break;
 				case Module::TYPE_M_CLOAKDISRUPTOR:
 					base->modules[i] = new FactoryModule(base, Module::TYPE_M_CLOAKDISRUPTOR);
+					break;
+				case Module::TYPE_FABRICATOR:
+					base->modules[i] = new FabricatorModule(base);
 					break;
 				default:
 					base->modules[i] = 0;

--- a/Plugins/Public/base_plugin/FabricatorModule.cpp
+++ b/Plugins/Public/base_plugin/FabricatorModule.cpp
@@ -12,7 +12,7 @@ FabricatorModule::~FabricatorModule()
 
 wstring FabricatorModule::GetInfo(bool xml)
 {
-	return L"Equipment Fabricator Bay";
+	return L"Equipment Fabrication Bay";
 }
 
 void FabricatorModule::LoadState(INI_Reader &ini)

--- a/Plugins/Public/base_plugin/FabricatorModule.cpp
+++ b/Plugins/Public/base_plugin/FabricatorModule.cpp
@@ -1,0 +1,28 @@
+#include "Main.h"
+
+
+FabricatorModule::FabricatorModule(PlayerBase *the_base)
+	: Module(TYPE_FABRICATOR), base(the_base)
+{
+}
+
+FabricatorModule::~FabricatorModule()
+{
+}
+
+wstring FabricatorModule::GetInfo(bool xml)
+{
+	return L"Equipment Fabricator Bay";
+}
+
+void FabricatorModule::LoadState(INI_Reader &ini)
+{
+	while (ini.read_value())
+	{
+	}
+}
+
+void FabricatorModule::SaveState(FILE *file)
+{
+	fprintf(file, "[FabricatorModule]\n");
+}

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -2541,6 +2541,29 @@ void Plugin_Communication_CallBack(PLUGIN_MESSAGE msg, void* data)
 			base->Save();
 		}
 	}
+	else if (msg == CUSTOM_BASE_QUERY_MODULE)
+	{
+		CUSTOM_BASE_QUERY_MODULE_STRUCT* info = reinterpret_cast<CUSTOM_BASE_QUERY_MODULE_STRUCT*>(data);
+		PlayerBase *base = GetPlayerBaseForClient(info->iClientID);
+		if (base)
+		{
+			returncode = SKIPPLUGINS;
+			bool retbool = false;
+			for (uint index = 1; index < base->modules.size(); index++)
+			{
+				if (base->modules[index])
+				{
+					Module *mod = (Module*)base->modules[index];
+					if (info->iModuleType == mod->type)
+					{
+						retbool = true;
+						break;
+					}
+				}
+			}
+			info->bExists = retbool;
+		}
+	}
 	return;
 }
 

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -84,7 +84,8 @@ public:
 	static const int TYPE_DEFENSE_2 = 9;
 	static const int TYPE_DEFENSE_3 = 10;
 	static const int TYPE_M_CLOAKDISRUPTOR = 11;
-	static const int TYPE_LAST = TYPE_M_CLOAKDISRUPTOR;
+	static const int TYPE_FABRICATOR = 12;
+	static const int TYPE_LAST = TYPE_FABRICATOR;
 
 	Module(uint the_type) : type(the_type) {}
 	virtual ~Module() {}
@@ -241,6 +242,19 @@ public:
 
 	bool AddToQueue(uint the_equipment_type);
 	bool ClearQueue();
+};
+
+class FabricatorModule : public Module
+{
+public:
+	PlayerBase *base;
+
+	FabricatorModule(PlayerBase *the_base);
+	~FabricatorModule();
+	wstring GetInfo(bool xml);
+
+	void LoadState(INI_Reader &ini);
+	void SaveState(FILE *file);
 };
 
 class BasePassword
@@ -584,6 +598,6 @@ wstring HtmlEncode(wstring text);
 extern string set_status_path_html;
 extern string set_status_path_json;
 
-extern const char* MODULE_TYPE_NICKNAMES[13];
+extern const char* MODULE_TYPE_NICKNAMES[14];
 
 #endif

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -349,6 +349,12 @@ void PlayerBase::Load()
 				mod->LoadState(ini);
 				modules.push_back(mod);
 			}
+			else if (ini.is_header("FabricatorModule"))
+			{
+				FabricatorModule *mod = new FabricatorModule(this);
+				mod->LoadState(ini);
+				modules.push_back(mod);
+			}
 		}
 		ini.close();
 	}

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -827,7 +827,8 @@ namespace PlayerCommands
 			PrintUserCmdText(client, L"|     <type> = 8 - cloaking device manufacturing factory");
 			PrintUserCmdText(client, L"|     <type> = 9 - defense platform array type 2");
 			PrintUserCmdText(client, L"|     <type> = 10 - defense platform array type 3");
-			PrintUserCmdText(client, L"|     <type> = 11 - Cloak Disruptor Factory");
+			PrintUserCmdText(client, L"|     <type> = 11 - cloak disruptor factory");
+			PrintUserCmdText(client, L"|     <type> = 12 - equipment fabrication bay");
 		}
 	}
 

--- a/Source/FLHookPluginSDK/headers/plugin.h
+++ b/Source/FLHookPluginSDK/headers/plugin.h
@@ -251,7 +251,8 @@ enum PLUGIN_MESSAGE
 	CLIENT_CLOAK_INFO = 44,
 	COMBAT_DAMAGE_OVERRIDE = 45,
 	CUSTOM_JUMP = 47,
-	CUSTOM_REVERSE_TRANSACTION = 48
+	CUSTOM_REVERSE_TRANSACTION = 48,
+	CUSTOM_BASE_QUERY_MODULE = 49
 };
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -332,6 +333,13 @@ struct CUSTOM_BASE_LAST_DOCKED_STRUCT
 {
 	uint iClientID;
 	uint iLastDockedBaseID;
+};
+
+struct CUSTOM_BASE_QUERY_MODULE_STRUCT
+{
+	uint iClientID;
+	uint iModuleType;
+	bool bExists;
 };
 
 struct CLIENT_CLOAK_STRUCT


### PR DESCRIPTION
The Equipment Fabrication Bay is a module that does nothing, but will be used in conjunction with the newly-added CUSTOM_BASE_QUERY_MODULE inter-plugin communication to implement equipment fabrication on POBs as well as NPC stations.

**This change requires an FLHook rebuild due to the addition of a new inter-plugin communication call.**