### PR TITLE
Class Difference Multipliers

### DIFF
--- a/Plugins/Public/pvecontroller/Main.cpp
+++ b/Plugins/Public/pvecontroller/Main.cpp
@@ -612,12 +612,9 @@ void __stdcall HkCb_AddDmgEntry(DamageList *dmg, unsigned short p1, float damage
 
 					map<int, float>::iterator itDiffMultiplier = mapClassDiffMultipliers.lower_bound(classDiff);
 					if (itDiffMultiplier != mapClassDiffMultipliers.end())
-						if (itDiffMultiplier->second != 1.0f) //We only need to modify the payout if the multiplier is not 1.
-						{
-							iBountyPayout *= itDiffMultiplier->second;
-							if (set_iPluginDebug >= PLUGIN_DEBUG_VERYVERBOSE)
-								PrintUserCmdText(iDmgFrom, L"PVECONTROLLER: Modifying payout to $%d (%0.2f of normal) due to class difference. %u vs %u \n", iBountyPayout, itDiffMultiplier->second, itKillerType->second, itVictimType->second);
-						}
+						iBountyPayout *= itDiffMultiplier->second;
+						if (set_iPluginDebug >= PLUGIN_DEBUG_VERYVERBOSE)
+							PrintUserCmdText(iDmgFrom, L"PVECONTROLLER: Modifying payout to $%d (%0.2f of normal) due to class difference. %u vs %u \n", iBountyPayout, itDiffMultiplier->second, itKillerType->second, itVictimType->second);
 				}
 
 				// If we've turned bounties off, don't pay it.

--- a/Plugins/Public/pvecontroller/Main.cpp
+++ b/Plugins/Public/pvecontroller/Main.cpp
@@ -614,7 +614,7 @@ void __stdcall HkCb_AddDmgEntry(DamageList *dmg, unsigned short p1, float damage
 					if (itDiffMultiplier != mapClassDiffMultipliers.end())
 						iBountyPayout *= itDiffMultiplier->second;
 						if (set_iPluginDebug >= PLUGIN_DEBUG_VERYVERBOSE)
-							PrintUserCmdText(iDmgFrom, L"PVECONTROLLER: Modifying payout to $%d (%0.2f of normal) due to class difference. %u vs %u \n", iBountyPayout, itDiffMultiplier->second, itKillerType->second, itVictimType->second);
+							PrintUserCmdText(iDmgFrom, L"PVECONTROLLER: Modifying payout to $%d (%0.2f x normal) due to class difference. %u vs %u \n", iBountyPayout, itDiffMultiplier->second, itKillerType->second, itVictimType->second);
 				}
 
 				// If we've turned bounties off, don't pay it.


### PR DESCRIPTION
Bounty Payout will be multiplied depending on the difference between ship class that killed the target NPC and the ship class of the target NPC.

Important:  LowerBound is used, while the code doesn't apply a modifier of 1.0, an entry that has a 1.0 modifier is needed.

Example Config entries:

; This groups the "shipclass" used in shiparchs into categories, or types, to simplify comparison for class-diff and allow the groupings themselves to be adjusted.
; class_type = class, ship_class1, ship_class2, ship_classN (can have as many or as few
class_type = 0, 0, 1, 3, 19
class_type = 1, 2, 4, 5, 6, 7, 8, 9, 10
class_type = 2, 11, 12
class_type = 3, 13, 14
class_type = 4, 15
class_type = 5, 16, 17, 18

; Scaling settings for payouts based on class difference of player that killed NPC.
; class_diff = diff, multiplier
class_diff = -2, 0.5
class_diff = -1, 0.8
class_diff = 0, 1
class_diff = 1, 1.12
class_diff = 2, 1.25
class_diff = 3, 1.5