### PR TITLE
Base will allow to buy stuff regardless to min_stock restriction

### DIFF
--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1653,7 +1653,7 @@ void __stdcall GFGoodBuy(struct SGFGoodBuyInfo const &gbi, unsigned int client)
 		const wstring &charname = (const wchar_t*)Players.GetActiveCharacterName(client);
 
 		// In theory, these should never be called.
-		if (count == 0 || base->market_items[gbi.iGoodID].min_stock >= base->market_items[gbi.iGoodID].quantity)
+		if (count == 0 || (base->market_items[gbi.iGoodID].min_stock >= base->market_items[gbi.iGoodID].quantity && !clients[client].admin))
 		{
 			PrintUserCmdText(client, L"ERR Base will not sell goods");
 			returncode = SKIPPLUGINS_NOFUNCTIONCALL;

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1669,7 +1669,7 @@ void __stdcall GFGoodBuy(struct SGFGoodBuyInfo const &gbi, unsigned int client)
 		}
 
 		if ((base->market_items[gbi.iGoodID].min_stock >= base->market_items[gbi.iGoodID].quantity && clients[client].admin))
-			PrintUserCmdText(client, L"OK Base would not sell goods due to min_stock restriction, but you are an admin, therefore it will");
+			PrintUserCmdText(client, L"Permitted player-owned base good sale in violation of shop's minimum stock value due to base admin login.");
 
 		clients[client].stop_buy = false;
 		base->RemoveMarketGood(gbi.iGoodID, count);

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1668,6 +1668,9 @@ void __stdcall GFGoodBuy(struct SGFGoodBuyInfo const &gbi, unsigned int client)
 			return;
 		}
 
+		if ((base->market_items[gbi.iGoodID].min_stock >= base->market_items[gbi.iGoodID].quantity && clients[client].admin))
+			PrintUserCmdText(client, L"OK Base would not sell goods due to min_stock restriction, but you are an admin, therefore it will");
+
 		clients[client].stop_buy = false;
 		base->RemoveMarketGood(gbi.iGoodID, count);
 		pub::Player::AdjustCash(client, 0 - price);


### PR DESCRIPTION
Suggesting so the player logged as admin could buy stuff regardless of min_stock restrictions. I changed shop settings too much, just to buy stuff and lock it back as unbuyable.