### PR TITLE
Base: Triggers weapon platforms from sum of damage

### DIFF
--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -104,6 +104,8 @@ map<string, ARCHTYPE_STRUCT> mapArchs;
 //commodities to watch for logging
 map<uint, wstring> listCommodities;
 
+//the hostility and weapon platform activation from damage caused by one player
+float damage_treshold = 100000;
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 PlayerBase *GetPlayerBase(uint base)
@@ -396,6 +398,10 @@ void LoadSettingsActual()
 					{
 						set_status_path_json = ini.get_value_string();
 					}
+					else if (ini.is_value("damage_treshold"))
+					{
+						damage_treshold; = ini.get_value_float(0);
+					}
 					else if (ini.is_value("status_export_type"))
 					{
 						ExportType = ini.get_value_int(0);
@@ -587,10 +593,6 @@ void LoadSettingsActual()
 						archstruct.logic = ini.get_value_int(0);
 					}
 					else if (ini.is_value("radius"))
-					{
-						archstruct.radius = ini.get_value_float(0);
-					}
-					else if (ini.is_value("damage_treshold"))
 					{
 						archstruct.radius = ini.get_value_float(0);
 					}

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -590,6 +590,10 @@ void LoadSettingsActual()
 					{
 						archstruct.radius = ini.get_value_float(0);
 					}
+					else if (ini.is_value("damage_treshold"))
+					{
+						archstruct.radius = ini.get_value_float(0);
+					}
 					else if (ini.is_value("idrestriction"))
 					{
 						archstruct.idrestriction = ini.get_value_int(0);

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -105,7 +105,7 @@ map<string, ARCHTYPE_STRUCT> mapArchs;
 map<uint, wstring> listCommodities;
 
 //the hostility and weapon platform activation from damage caused by one player
-float damage_treshold = 100000;
+float damage_treshold = 400000;
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 PlayerBase *GetPlayerBase(uint base)
@@ -400,7 +400,7 @@ void LoadSettingsActual()
 					}
 					else if (ini.is_value("damage_treshold"))
 					{
-						damage_treshold; = ini.get_value_float(0);
+						damage_treshold = ini.get_value_float(0);
 					}
 					else if (ini.is_value("status_export_type"))
 					{

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -358,6 +358,7 @@ public:
 
 	// List of ships that are hostile to this base
 	map<wstring, wstring> hostile_tags;
+	map<wstring, float> hostile_tags_damage;
 
 	// List of ships that are permanently hostile to this base
 	list<wstring> perma_hostile_tags;
@@ -401,6 +402,9 @@ public:
 
 	//the destination vector
 	Vector destposition;
+
+	//the hostility and weapon platform activation from damage caused by one player
+	float damage_treshold;
 	/////////////////////////////////////////
 };
 

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -403,8 +403,6 @@ public:
 	//the destination vector
 	Vector destposition;
 
-	//the hostility and weapon platform activation from damage caused by one player
-	float damage_treshold;
 	/////////////////////////////////////////
 };
 
@@ -593,4 +591,5 @@ extern string set_status_path_json;
 
 extern const char* MODULE_TYPE_NICKNAMES[13];
 
+extern float damage_treshold;
 #endif

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -677,7 +677,16 @@ float PlayerBase::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 			{
 				if (set_plugin_debug > 1)
 					ConPrint(L"PlayerBase::damaged space_obj=%u\n", space_obj);
-				hostile_tags[charname] = charname;
+				
+				if (hostile_tags_damage.find(charname) != hostile_tags_damage.end())
+				{
+					if (hostile_tags_damage[charname] < damage_treshold)
+						hostile_tags_damage[charname] += damage;
+					else hostile_tags[charname] = charname;
+				}
+				else hostile_tags_damage[charname] = damage;
+					
+
 				SyncReputationForBase();
 			}
 		}


### PR DESCRIPTION
This change makes neutral or friendly aligned weapon platforms triggered to hostile state not just from any damage 
but from certain sum of damage performed by one player during 24 hours
for example, 200000 (float setting damage_treshold is added for config file)

Every player has separate counter remembering how much damage they did to base (attached to their ship name)