### PR TITLE
base: Allow /bank deposit and status without admin access

### DIFF
--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -1129,11 +1129,6 @@ namespace PlayerCommands
 	void Bank(uint client, const wstring &args)
 	{
 		PlayerBase *base = GetPlayerBaseForClient(client);
-		if (!clients[client].admin)
-		{
-			PrintUserCmdText(client, L"ERR Access denied");
-			return;
-		}
 
 		const wstring &cmd = GetParam(args, ' ', 1);
 		int money = ToInt(GetParam(args, ' ', 2));
@@ -1142,6 +1137,12 @@ namespace PlayerCommands
 
 		if (cmd == L"withdraw")
 		{
+			if (!clients[client].admin)
+			{
+				PrintUserCmdText(client, L"ERR Access denied");
+				return;
+			}
+
 			float fValue;
 			pub::Player::GetAssetValue(client, fValue);
 


### PR DESCRIPTION
Players want the ability to donate to pob banks without admin access.
So if admin is not present, they can donate some money and keep the base floating with supplies it would not accept otherwise.