### PR TITLE
base: Allow repairing bases with credits from the bank (12.10.20)

### DIFF
--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -95,6 +95,10 @@ bool load_settings_required = true;
 /// holiday mode
 bool set_holiday_mode = false;
 
+// repair with money
+bool disable_fow_for_all_bases = true;
+INT64 money_per_repair_material = 1000;
+
 //pob sounds struct
 POBSOUNDS pbsounds;
 
@@ -458,6 +462,14 @@ void LoadSettingsActual()
 						uint good = CreateID(ini.get_value_string(0));
 						uint quantity = ini.get_value_int(1);
 						shield_power_items[good] = quantity;
+					}
+					else if (ini.is_value("disable_fow_for_all_bases"))
+					{
+						disable_fow_for_all_bases = ini.get_value_bool(0);
+					}
+					else if (ini.is_value("money_per_repair_material"))
+					{
+						money_per_repair_material = ini.get_value_int(0);
 					}
 					else if (ini.is_value("set_new_spawn"))
 					{
@@ -997,7 +1009,7 @@ bool UserCmd_Process(uint client, const wstring &args)
 		PlayerCommands::BaseLstHostileTag(client, args);
 		return true;
 	}
-	else if (args.find(L"/base rep") == 0)
+	else if (args.find(L"/base setrep") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		PlayerCommands::BaseRep(client, args);
@@ -1049,6 +1061,12 @@ bool UserCmd_Process(uint client, const wstring &args)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		PlayerCommands::BaseShieldMod(client, args);
+		return true;
+	}
+	else if (args.find(L"/base repair") == 0)
+	{
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+		PlayerCommands::BaseRepairMod(client, args);
 		return true;
 	}
 	else if (args.find(L"/base buildmod") == 0)

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -374,6 +374,9 @@ public:
 	// if true, the base was repaired or is able to be repaired
 	bool repairing;
 
+	//Set repairing way (0 - off, 1 - on(with repair materials + credits if health is full), 2 - nomoney(with repair materials only))
+	int set_repairing_way = 1;
+
 	// The state of the shield
 	static const int SHIELD_STATE_OFFLINE = 0;
 	static const int SHIELD_STATE_ONLINE = 1;
@@ -500,6 +503,7 @@ namespace PlayerCommands
 	void BaseBuildMod(uint client, const wstring &args);
 	void BaseFacMod(uint client, const wstring &args);
 	void BaseShieldMod(uint client, const wstring &args);
+	void BaseRepairMod(uint client, const wstring &args);
 	void Bank(uint client, const wstring &args);
 	void Shop(uint client, const wstring &args);
 
@@ -581,6 +585,10 @@ extern float set_shield_damage_multiplier;
 
 /// Holiday mode
 extern bool set_holiday_mode;
+
+// repair with money
+extern bool disable_fow_for_all_bases;
+extern INT64 money_per_repair_material;
 
 wstring HtmlEncode(wstring text);
 

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -264,6 +264,15 @@ void PlayerBase::Load()
 							defense_mode = 1;
 						}
 					}
+					else if (ini.is_value("repairmode"))
+					{
+						set_repairing_way = ini.get_value_int(0);
+
+						if (set_repairing_way <0 || set_repairing_way >=2)
+						{
+							set_repairing_way = 1;
+						}
+					}
 					else if (ini.is_value("ally_tag"))
 					{
 						wstring tag;
@@ -392,6 +401,7 @@ void PlayerBase::Save()
 		}
 
 		fprintf(file, "defensemode = %u\n", defense_mode);
+		fprintf(file, "repairmode = %u\n", set_repairing_way);
 		foreach(ally_tags, wstring, i)
 		{
 			ini_write_wstring(file, "ally_tag", *i);

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -1126,6 +1126,56 @@ namespace PlayerCommands
 		PrintUserCmdText(client, L"OK");
 	}
 
+	void BaseRepairMod(uint client, const wstring &args)
+	{
+		PlayerBase *base = GetPlayerBaseForClient(client);
+		if (!base)
+		{
+			PrintUserCmdText(client, L"ERR Not in player base");
+			return;
+		}
+
+		if (!clients[client].admin)
+		{
+			PrintUserCmdText(client, L"ERR Access denied");
+			return;
+		}
+
+		const wstring &cmd = GetParam(args, ' ', 2);
+		if (cmd == L"on")
+		{
+			base->set_repairing_way = 1;
+		}
+		else if (cmd == L"off")
+		{
+			base->set_repairing_way = 0;
+		}
+		else if (cmd == L"legacy")
+		{
+			base->set_repairing_way = 2;
+		}
+		else if (cmd == L"status")
+		{
+			if (base->set_repairing_way == 0)
+				PrintUserCmdText(client, L"|  repair status: off");
+			if (base->set_repairing_way == 1)
+				PrintUserCmdText(client, L"|  repair status: on");
+			if (base->set_repairing_way == 2)
+				PrintUserCmdText(client, L"|  repair status: legacy");
+		}
+		else
+		{
+			PrintUserCmdText(client, L"ERR Invalid parameters");
+			PrintUserCmdText(client, L"/base repair [on|off]nomoney|status");
+			PrintUserCmdText(client, L"|  on - repair with everything");
+			PrintUserCmdText(client, L"|  off - turn the repairs off");
+			PrintUserCmdText(client, L"|  legacy - repair with repair materials only");
+			PrintUserCmdText(client, L"|  status - shows your repair way");
+		}
+
+		PrintUserCmdText(client, L"OK");
+	}
+
 	void Bank(uint client, const wstring &args)
 	{
 		PlayerBase *base = GetPlayerBaseForClient(client);


### PR DESCRIPTION
replacement to this branch https://github.com/DiscoveryGC/FLHook/pull/109
I had difficulties restoring old one
+I remade heavily anyway;

What I fixed: 
1) any repair mod can be turned on/off now by base owner.
2) it works precisely only when base is having 100% health now, and just blocks tear/wear damage with substracting necessary money instead of real repairs.

btw description of idea behind it just in case:
when base is damaged or in siege, it is repaired with repair materials as usual
when it has 100% health, it is repaired with money (I made it as a thing that can turned on/off by base owner)
FOW is just removed.