### PR TITLE
minecontrol, event: feature, miner's notifications (12.10.20)

### DIFF
--- a/Plugins/Public/event/Main.cpp
+++ b/Plugins/Public/event/Main.cpp
@@ -839,6 +839,7 @@ void __stdcall GFGoodSell_AFTER(struct SGFGoodSellInfo const &gsi, unsigned int 
 	//MiningEvent_Sale(gsi, iClientID);
 }
 
+map<uint, uint> last_time_of_notice;
 void __stdcall SPMunitionCollision(struct SSPMunitionCollisionInfo const & ci, unsigned int iClientID)
 {
 	returncode = DEFAULT_RETURNCODE;
@@ -914,7 +915,22 @@ void __stdcall SPMunitionCollision(struct SSPMunitionCollisionInfo const & ci, u
 		}
 		if (iLootCount == 0)
 		{
-			pub::Player::SendNNMessage(iClientID, CreateID("insufficient_cargo_space"));
+			uint LastTime;
+			if (last_time_of_notice.find(iClientID) == last_time_of_notice.end())
+				LastTime = 0;
+			else LastTime = last_time_of_notice[iClientID];
+
+			if (((uint)time(0) - LastTime) > 1)
+			{
+				PrintUserCmdText(iClientID, L"%s's cargo is now full.", reinterpret_cast<const wchar_t*>(Players.GetActiveCharacterName(iSendToClientID)));
+				pub::Player::SendNNMessage(iClientID, CreateID("insufficient_cargo_space"));
+				if (iClientID != iSendToClientID)
+				{
+					PrintUserCmdText(iSendToClientID, L"Your cargo is now full.");
+					pub::Player::SendNNMessage(iSendToClientID, CreateID("insufficient_cargo_space"));
+				}
+				last_time_of_notice[iClientID] = (uint)time(0);
+			}
 			return;
 		}
 


### PR DESCRIPTION
Continuing issue https://github.com/DiscoveryGC/FLHook/issues/48
While using Laz's closed pull request: https://github.com/DiscoveryGC/FLHook/pull/76
While slightly editing it, so there would be no repeatable phrases too much at one time. 
(made checking for one-second difference between msgs to the same address)

Short description: Besides sound, there will be console notification about miner's cargo full for miner and target transport.
(Instead of just sound only for miner)