### PR TITLE
playercntl: Command /resetrep - to reset all reputations (12.10.20)

### DIFF
--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -943,6 +943,7 @@ USERCMD UserCmds[] =
 	{ L"/pos",			MiscCmds::UserCmd_Pos,			L"Usage: /pos" },
 	{ L"/stuck",		MiscCmds::UserCmd_Stuck,		L"Usage: /stuck" },
 	{ L"/droprep",		MiscCmds::UserCmd_DropRep,		L"Usage: /droprep" },
+	{ L"/resetrep",		MiscCmds::UserCmd_ResetRep,		L"Usage: /resetrep" },
 	{ L"/dice",			MiscCmds::UserCmd_Dice,			L"Usage: /dice 1d20 | 1d20+3 | etc."},
 	{ L"/roll",			MiscCmds::UserCmd_Dice,			L"Usage: /roll 1d20 | 1d20+3 | etc." },
 	{ L"/coin",			MiscCmds::UserCmd_Coin,			L"Usage: /coin" },

--- a/Plugins/Public/playercntl_plugin/Main.h
+++ b/Plugins/Public/playercntl_plugin/Main.h
@@ -78,6 +78,10 @@ namespace Rename
 namespace MiscCmds
 {
 	void LoadSettings(const string &scPluginCfgFile);
+	void LoadListOfReps();
+	map<wstring, uint> Resetrep_load_Time_limits_for_player_account(string filename);
+	void Resetrep_save_Time_limits_to_player_account(string filename, map<wstring,uint> tempmap);
+
 	void ClearClientInfo(uint iClientID);
 	void BaseEnter(unsigned int iBaseID, unsigned int iClientID);
 	void CharacterInfoReq(unsigned int iClientID, bool p2);
@@ -87,6 +91,7 @@ namespace MiscCmds
 	bool UserCmd_Stuck(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage);
 	bool UserCmd_Dice(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage);
 	bool UserCmd_DropRep(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage);
+	bool UserCmd_ResetRep(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage);
 	bool UserCmd_Coin(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage);
 
 	bool UserCmd_Lights(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage);

--- a/Plugins/Public/playercntl_plugin/Rename.cpp
+++ b/Plugins/Public/playercntl_plugin/Rename.cpp
@@ -471,7 +471,7 @@ namespace Rename
 				HK_ERROR err;
 				if ((err = HkGetAccountDirName(o.wscNewCharname, wscDir)) != HKE_OK)
 				{
-					ConPrint(L"ERR 461 " + HkErrGetText(err));
+					ConPrint(L"ERR Resetrep failure in rename to get directory\n");
 				}
 				else
 				{


### PR DESCRIPTION
Descritiption: when /resetrep is used. It will nullify all reputations to zero like in fresh restart
What is it for? to restore broken reputations after changing IDs.

Restrictions for usage: 
1) It can be used only in base + it kicks (for logging to rephack your reps according to your ID)
2) It takes some credits (default price 10'000'000)
3) It can be used only once in two weeks, cooldown is resistant to renameme and movechar operations.
