### PR TITLE
base: remove hostile tagged players from base to proxy

### DIFF
--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1273,12 +1273,15 @@ bool IsPlayerAuthorizedOnBase(uint client)
 	//And it is used for hostile players being redirected to proxy base
 	//in cases when they were having for some reason access to PoB and after that they were added as enemies.
 	PlayerBase *base = GetPlayerBaseForClient(client);
-	wstring charname = (const wchar_t*)Players.GetActiveCharacterName(client);
-	for (std::list<wstring>::const_iterator i = base->perma_hostile_tags.begin(); i != base->perma_hostile_tags.end(); ++i)
+	if (!base)
 	{
-		if (charname.find(*i) == 0)
+		wstring charname = (const wchar_t*)Players.GetActiveCharacterName(client);
+		for (std::list<wstring>::const_iterator i = base->perma_hostile_tags.begin(); i != base->perma_hostile_tags.end(); ++i)
 		{
-			return false;
+			if (charname.find(*i) == 0)
+			{
+				return false;
+			}
 		}
 	}
 	return true;


### PR DESCRIPTION
This change makes sure that players who were added to /base addhostile
Will be exiting base at the proxy (100k below sun).
Their access to the base will be stripped fully when they exit base or log out of the game, changing their resurrecting point to proxy base.

What is it for? For situations when pirates dock neutral to them pob and begin hunting base owners.
And just adding to the hostile list is not enough, since they can suicide to return back. It prevents it.

Sort of delayed 'kick' from a base, making sure that hostile list works better.
