### PR TITLE
base: weapon platform hostility delay.

### DIFF
--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -104,6 +104,8 @@ map<string, ARCHTYPE_STRUCT> mapArchs;
 //commodities to watch for logging
 map<uint, wstring> listCommodities;
 
+//the hostility and weapon platform activation from damage caused by one player
+float damage_threshold = 400000;
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 PlayerBase *GetPlayerBase(uint base)
@@ -395,6 +397,10 @@ void LoadSettingsActual()
 					else if (ini.is_value("status_path_json"))
 					{
 						set_status_path_json = ini.get_value_string();
+					}
+					else if (ini.is_value("damage_threshold"))
+					{
+						damage_threshold = ini.get_value_float(0);
 					}
 					else if (ini.is_value("status_export_type"))
 					{

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -361,6 +361,7 @@ public:
 
 	// List of ships that are hostile to this base
 	map<wstring, wstring> hostile_tags;
+	map<wstring, float> hostile_tags_damage;
 
 	// List of ships that are permanently hostile to this base
 	list<wstring> perma_hostile_tags;
@@ -404,6 +405,7 @@ public:
 
 	//the destination vector
 	Vector destposition;
+
 	/////////////////////////////////////////
 };
 
@@ -592,4 +594,5 @@ extern string set_status_path_json;
 
 extern const char* MODULE_TYPE_NICKNAMES[13];
 
+extern float damage_threshold;
 #endif

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -677,7 +677,15 @@ float PlayerBase::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 			{
 				if (set_plugin_debug > 1)
 					ConPrint(L"PlayerBase::damaged space_obj=%u\n", space_obj);
-				hostile_tags[charname] = charname;
+				
+				if (hostile_tags_damage.find(charname) == hostile_tags_damage.end())
+					hostile_tags_damage[charname] = 0;
+
+				if ((hostile_tags_damage[charname] + damage) < damage_threshold)
+					hostile_tags_damage[charname] += damage;
+				else hostile_tags[charname] = charname;
+					
+
 				SyncReputationForBase();
 			}
 		}


### PR DESCRIPTION
Creating to replace https://github.com/DiscoveryGC/FLHook/pull/120 which was broken due to force pushed commits. Apperently I should re open PR before force pushing commits, if I don't want to close PR forever.

Description:
This change makes neutral or friendly aligned weapon platforms triggered to hostile state not just from any damage
but from certain sum of damage performed by one player during 24 hours
for example, 400000 (float setting damage_threshold is added for config file)
Every player has separate counter remembering how much damage they did to base (attached to their ship name)