### PR TITLE
feat(set_admin): new groups, chasepull and aicontrol

### DIFF
--- a/Plugins/Public/alley/PlayerRestrictions.cpp
+++ b/Plugins/Public/alley/PlayerRestrictions.cpp
@@ -429,12 +429,6 @@ bool GiftCmd(uint iClientID, const wstring &wscCmd, const wstring &wscParam, con
 
 void AdminCmd_GenerateID(CCmds* cmds, wstring argument)
 {
-	if (cmds->rights != RIGHT_SUPERADMIN)
-	{
-		cmds->Print(L"ERR No permission\n");
-		return;
-	}
-
 	uint thegeneratedid = CreateID(wstos(argument).c_str());
 
 	string s;
@@ -768,24 +762,19 @@ bool UserCmd_Process(uint iClientID, const wstring &wscCmd)
 }
 
 #define IS_CMD(a) !wscCmd.compare(L##a)
-#define RIGHT_CHECK(a) if(!(cmds->rights & a)) { cmds->Print(L"ERR No permission\n"); return true; }
 bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 {
 	returncode = DEFAULT_RETURNCODE;
 
-	if (IS_CMD("showrestrictions"))
+	if (IS_CMD("generateid"))
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 
-		RIGHT_CHECK(RIGHT_SUPERADMIN)
-
-		return true;
-	}
-	else if (IS_CMD("generateid"))
-	{
-		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
-
-		RIGHT_CHECK(RIGHT_SUPERADMIN)
+		if (cmds->rights != RIGHT_SUPERADMIN)
+		{
+			cmds->Print(L"ERR No permission\n");
+			return true;
+		}
 
 		AdminCmd_GenerateID(cmds, cmds->ArgStrToEnd(1));
 		return true;
@@ -794,8 +783,17 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		HKPLAYERINFO adminPlyr;
-		
-		RIGHT_CHECK(RIGHT_SUPERADMIN)
+		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK)
+		{
+			cmds->Print(L"ERR\n");
+			return true;
+		}
+
+		if (cmds->rights != RIGHT_SUPERADMIN)
+		{
+			cmds->Print(L"ERR No permission\n");
+			return true;
+		}
 
 		Archetype::Ship* TheShipArch = Archetype::GetShip(Players[adminPlyr.iClientID].iShipArchetype);
 		PrintUserCmdText(adminPlyr.iClientID, L"The secret code is %d", TheShipArch->iArchID);
@@ -806,8 +804,17 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		HKPLAYERINFO adminPlyr;
-		
-		RIGHT_CHECK(RIGHT_SUPERADMIN)
+		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK)
+		{
+			cmds->Print(L"ERR\n");
+			return true;
+		}
+
+		if (cmds->rights != RIGHT_SUPERADMIN)
+		{
+			cmds->Print(L"ERR No permission\n");
+			return true;
+		}
 
 		uint iShip;
 		pub::Player::GetShip(adminPlyr.iClientID, iShip);
@@ -823,8 +830,17 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		HKPLAYERINFO adminPlyr;
-		
-		RIGHT_CHECK(RIGHT_SUPERADMIN)
+		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK)
+		{
+			cmds->Print(L"ERR\n");
+			return true;
+		}
+
+		if (cmds->rights != RIGHT_SUPERADMIN)
+		{
+			cmds->Print(L"ERR No permission\n");
+			return true;
+		}
 
 		uint iShip;
 		pub::Player::GetShip(adminPlyr.iClientID, iShip);
@@ -868,7 +884,11 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	}
 	else if (IS_CMD("testfuseobj"))
 	{
-		RIGHT_CHECK(RIGHT_SUPERADMIN)
+		if (cmds->rights != RIGHT_SUPERADMIN)
+		{
+			cmds->Print(L"ERR No permission\n");
+			return true;
+		}
 
 		HKPLAYERINFO adminPlyr;
 		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
@@ -886,7 +906,11 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	}
 	else if (IS_CMD("testunfuseobj"))
 	{
-		RIGHT_CHECK(RIGHT_SUPERADMIN)
+		if (cmds->rights != RIGHT_SUPERADMIN)
+		{
+			cmds->Print(L"ERR No permission\n");
+			return true;
+		}
 
 		HKPLAYERINFO adminPlyr;
 		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
@@ -912,7 +936,11 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	}
 	else if (IS_CMD("testselffuseobj"))
 	{
-	RIGHT_CHECK(RIGHT_SUPERADMIN)
+		if (cmds->rights != RIGHT_SUPERADMIN)
+		{
+			cmds->Print(L"ERR No permission\n");
+			return true;
+		}
 
 		HKPLAYERINFO adminPlyr;
 		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
@@ -928,7 +956,11 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	}
 	else if (IS_CMD("testselfunfuseobj"))
 	{
-		RIGHT_CHECK(RIGHT_SUPERADMIN)
+		if (cmds->rights != RIGHT_SUPERADMIN)
+		{
+			cmds->Print(L"ERR No permission\n");
+			return true;
+		}
 
 		HKPLAYERINFO adminPlyr;
 		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)

--- a/Plugins/Public/alley/PlayerRestrictions.cpp
+++ b/Plugins/Public/alley/PlayerRestrictions.cpp
@@ -768,7 +768,7 @@ bool UserCmd_Process(uint iClientID, const wstring &wscCmd)
 }
 
 #define IS_CMD(a) !wscCmd.compare(L##a)
-
+#define RIGHT_CHECK(a) if(!(cmds->rights & a)) { cmds->Print(L"ERR No permission\n"); return true; }
 bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 {
 	returncode = DEFAULT_RETURNCODE;
@@ -776,11 +776,17 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	if (IS_CMD("showrestrictions"))
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+
+		RIGHT_CHECK(RIGHT_SUPERADMIN)
+
 		return true;
 	}
 	else if (IS_CMD("generateid"))
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+
+		RIGHT_CHECK(RIGHT_SUPERADMIN)
+
 		AdminCmd_GenerateID(cmds, cmds->ArgStrToEnd(1));
 		return true;
 	}
@@ -788,11 +794,8 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK)
-		{
-			cmds->Print(L"ERR\n");
-			return true;
-		}
+		
+		RIGHT_CHECK(RIGHT_SUPERADMIN)
 
 		Archetype::Ship* TheShipArch = Archetype::GetShip(Players[adminPlyr.iClientID].iShipArchetype);
 		PrintUserCmdText(adminPlyr.iClientID, L"The secret code is %d", TheShipArch->iArchID);
@@ -803,11 +806,8 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK)
-		{
-			cmds->Print(L"ERR\n");
-			return true;
-		}
+		
+		RIGHT_CHECK(RIGHT_SUPERADMIN)
 
 		uint iShip;
 		pub::Player::GetShip(adminPlyr.iClientID, iShip);
@@ -823,11 +823,8 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		HKPLAYERINFO adminPlyr;
-		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK)
-		{
-			cmds->Print(L"ERR\n");
-			return true;
-		}
+		
+		RIGHT_CHECK(RIGHT_SUPERADMIN)
 
 		uint iShip;
 		pub::Player::GetShip(adminPlyr.iClientID, iShip);
@@ -871,11 +868,7 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	}
 	else if (IS_CMD("testfuseobj"))
 	{
-		if (cmds->rights != RIGHT_SUPERADMIN)
-		{
-			cmds->Print(L"ERR No permission\n");
-			return true;
-		}
+		RIGHT_CHECK(RIGHT_SUPERADMIN)
 
 		HKPLAYERINFO adminPlyr;
 		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
@@ -893,11 +886,7 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	}
 	else if (IS_CMD("testunfuseobj"))
 	{
-		if (cmds->rights != RIGHT_SUPERADMIN)
-		{
-			cmds->Print(L"ERR No permission\n");
-			return true;
-		}
+		RIGHT_CHECK(RIGHT_SUPERADMIN)
 
 		HKPLAYERINFO adminPlyr;
 		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
@@ -923,11 +912,7 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	}
 	else if (IS_CMD("testselffuseobj"))
 	{
-		if (cmds->rights != RIGHT_SUPERADMIN)
-		{
-			cmds->Print(L"ERR No permission\n");
-			return true;
-		}
+	RIGHT_CHECK(RIGHT_SUPERADMIN)
 
 		HKPLAYERINFO adminPlyr;
 		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)
@@ -943,11 +928,7 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	}
 	else if (IS_CMD("testselfunfuseobj"))
 	{
-		if (cmds->rights != RIGHT_SUPERADMIN)
-		{
-			cmds->Print(L"ERR No permission\n");
-			return true;
-		}
+		RIGHT_CHECK(RIGHT_SUPERADMIN)
 
 		HKPLAYERINFO adminPlyr;
 		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1955,7 +1955,7 @@ static void ForcePlayerBaseDock(uint client, PlayerBase *base)
 }
 
 #define IS_CMD(a) !args.compare(L##a)
-
+#define RIGHT_CHECK(a) if(!(cmd->rights & a)) { cmd->Print(L"ERR No permission\n"); return true; }
 bool ExecuteCommandString_Callback(CCmds* cmd, const wstring &args)
 {
 	returncode = DEFAULT_RETURNCODE;
@@ -2000,9 +2000,12 @@ bool ExecuteCommandString_Callback(CCmds* cmd, const wstring &args)
 		}
 		return true;
 	}*/
+
 	if (args.find(L"testrecipe") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+
+		RIGHT_CHECK(RIGHT_BASES)
 
 		uint client = HkGetClientIdFromCharname(cmd->GetAdminName());
 		PlayerBase *base = GetPlayerBaseForClient(client);
@@ -2028,6 +2031,9 @@ bool ExecuteCommandString_Callback(CCmds* cmd, const wstring &args)
 	else if (args.find(L"testdeploy") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+
+		RIGHT_CHECK(RIGHT_BASES)
+
 		uint client = HkGetClientIdFromCharname(cmd->GetAdminName());
 		if (!client)
 		{
@@ -2099,6 +2105,8 @@ bool ExecuteCommandString_Callback(CCmds* cmd, const wstring &args)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 
+		RIGHT_CHECK(RIGHT_BASES)
+
 		uint client = HkGetClientIdFromCharname(cmd->GetAdminName());
 
 		//return SpaceObjDestroyed(space_obj);
@@ -2133,6 +2141,8 @@ bool ExecuteCommandString_Callback(CCmds* cmd, const wstring &args)
 	else if (args.find(L"basetogglegod") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+
+		RIGHT_CHECK(RIGHT_BASES)
 
 		uint client = HkGetClientIdFromCharname(cmd->GetAdminName());
 		bool optype = cmd->ArgInt(1);
@@ -2176,6 +2186,9 @@ bool ExecuteCommandString_Callback(CCmds* cmd, const wstring &args)
 	else if (args.find(L"testbase") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+
+		RIGHT_CHECK(RIGHT_BASES)
+
 		uint client = HkGetClientIdFromCharname(cmd->GetAdminName());
 
 		uint ship;
@@ -2243,6 +2256,8 @@ bool ExecuteCommandString_Callback(CCmds* cmd, const wstring &args)
 	else if (args.find(L"jumpcreate") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+
+		RIGHT_CHECK(RIGHT_BASES)
 
 		uint client = HkGetClientIdFromCharname(cmd->GetAdminName());
 		PlayerBase *base = GetPlayerBaseForClient(client);
@@ -2368,6 +2383,8 @@ bool ExecuteCommandString_Callback(CCmds* cmd, const wstring &args)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 
+		RIGHT_CHECK(RIGHT_BASES)
+
 		uint client = HkGetClientIdFromCharname(cmd->GetAdminName());
 		PlayerBase *base = GetPlayerBaseForClient(client);
 
@@ -2472,6 +2489,9 @@ bool ExecuteCommandString_Callback(CCmds* cmd, const wstring &args)
 	else if (args.find(L"basedebugon") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+
+		RIGHT_CHECK(RIGHT_BASES)
+
 		set_plugin_debug = 1;
 		cmd->Print(L"OK base debug is on, sure hope you know what you're doing here.\n");
 		return true;
@@ -2479,6 +2499,9 @@ bool ExecuteCommandString_Callback(CCmds* cmd, const wstring &args)
 	else if (args.find(L"basedebugoff") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+
+		RIGHT_CHECK(RIGHT_BASES)
+
 		set_plugin_debug = 0;
 		cmd->Print(L"OK base debug is off.\n");
 		return true;

--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -805,6 +805,9 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 
 		uint iClientID = HkGetClientIdFromCharname(cmds->GetAdminName());
+		
+		if (!(cmds->rights & RIGHT_CLOAK)) { cmds->Print(L"ERR No permission\n"); return true; }
+		
 		if (iClientID == -1)
 		{
 			cmds->Print(L"ERR On console");

--- a/Plugins/Public/npc_control/Main.cpp
+++ b/Plugins/Public/npc_control/Main.cpp
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <iostream>
 
+#define RIGHT_CHECK(a) if(!(cmds->rights & a)) { cmds->Print(L"ERR No permission\n"); return; }
 static int set_iPluginDebug = 0;
 
 /// A return code to indicate to FLHook if we want the hook processing to continue.
@@ -542,11 +543,7 @@ void CreateNPC(wstring name, Vector pos, Matrix rot, uint iSystem)
 
 void AdminCmd_AIMake(CCmds* cmds, int Amount, wstring NpcType)
 {
-	if (cmds->rights != RIGHT_SUPERADMIN)
-	{
-		cmds->Print(L"ERR No permission\n");
-		return;
-	}
+	RIGHT_CHECK(RIGHT_AICONTROL)
 
 	if (Amount == 0) { Amount = 1; }
 
@@ -589,11 +586,8 @@ void AdminCmd_AIMake(CCmds* cmds, int Amount, wstring NpcType)
 
 void AdminCmd_AIKill(CCmds* cmds, int loot)
 {
-	if (cmds->rights != RIGHT_SUPERADMIN)
-	{
-		cmds->Print(L"ERR No permission\n");
-		return;
-	}
+	RIGHT_CHECK(RIGHT_AICONTROL)
+
 	int num = loot;
 	if (num >= 2)
 		num = 0;
@@ -611,11 +605,7 @@ void AdminCmd_AIKill(CCmds* cmds, int loot)
 /* Make AI come to your position */
 void AdminCmd_AICome(CCmds* cmds)
 {
-	if (cmds->rights != RIGHT_SUPERADMIN)
-	{
-		cmds->Print(L"ERR No permission\n");
-		return;
-	}
+	RIGHT_CHECK(RIGHT_AICONTROL)
 
 	uint iShip1;
 	pub::Player::GetShip(HkGetClientIdFromCharname(cmds->GetAdminName()), iShip1);
@@ -647,11 +637,7 @@ void AdminCmd_AICome(CCmds* cmds)
 /* Make AI follow you until death */
 void AdminCmd_AIFollow(CCmds* cmds, wstring &wscCharname)
 {
-	if (cmds->rights != RIGHT_SUPERADMIN)
-	{
-		cmds->Print(L"ERR No permission\n");
-		return;
-	}
+	RIGHT_CHECK(RIGHT_AICONTROL)
 
 	// If no player specified follow the admin
 	uint iClientId;
@@ -692,11 +678,7 @@ void AdminCmd_AIFollow(CCmds* cmds, wstring &wscCharname)
 /* Cancel the current operation */
 void AdminCmd_AICancel(CCmds* cmds)
 {
-	if (cmds->rights != RIGHT_SUPERADMIN)
-	{
-		cmds->Print(L"ERR No permission\n");
-		return;
-	}
+	RIGHT_CHECK(RIGHT_AICONTROL)
 
 	uint iShip1;
 	pub::Player::GetShip(HkGetClientIdFromCharname(cmds->GetAdminName()), iShip1);
@@ -715,11 +697,7 @@ void AdminCmd_AICancel(CCmds* cmds)
 /** List npc fleets */
 void AdminCmd_ListNPCFleets(CCmds* cmds)
 {
-	if (cmds->rights != RIGHT_SUPERADMIN)
-	{
-		cmds->Print(L"ERR No permission\n");
-		return;
-	}
+	RIGHT_CHECK(RIGHT_AICONTROL)
 
 	cmds->Print(L"Available fleets: %d\n", mapNPCFleets.size());
 	for (map<wstring, NPC_FLEETSTRUCT>::iterator i = mapNPCFleets.begin();
@@ -736,11 +714,7 @@ void AdminCmd_ListNPCFleets(CCmds* cmds)
 /* Spawn a Fleet */
 void AdminCmd_AIFleet(CCmds* cmds, wstring FleetName)
 {
-	if (cmds->rights != RIGHT_SUPERADMIN)
-	{
-		cmds->Print(L"ERR No permission\n");
-		return;
-	}
+	RIGHT_CHECK(RIGHT_AICONTROL)
 
 	int wrongnpcname = 0;
 

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -22,6 +22,8 @@
 #include "Main.h"
 #include <hookext_exports.h>
 
+#define RIGHT_CHECK(a) if(!(cmds->rights & a)) { cmds->Print(L"ERR No permission\n"); return; }
+
 namespace HyperJump
 {
 	// Check that the item is a ship, cargo or equipment item is valid
@@ -1058,11 +1060,7 @@ namespace HyperJump
 	/** Chase a player. Works across systems but needs improvement of the path selection algorithm */
 	void HyperJump::AdminCmd_Chase(CCmds* cmds, const wstring &wscCharname)
 	{
-		if (cmds->rights != RIGHT_SUPERADMIN)
-		{
-			cmds->Print(L"ERR No permission\n");
-			return;
-		}
+		RIGHT_CHECK(RIGHT_CHASEPULL)
 
 		HKPLAYERINFO adminPlyr;
 		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK)
@@ -1165,11 +1163,7 @@ namespace HyperJump
 	/** Pull a player to you. Works across systems but needs improvement of the path selection algorithm */
 	void HyperJump::AdminCmd_Pull(CCmds* cmds, const wstring &wscCharname)
 	{
-		if (cmds->rights != RIGHT_SUPERADMIN)
-		{
-			cmds->Print(L"ERR No permission\n");
-			return;
-		}
+		RIGHT_CHECK(RIGHT_CHASEPULL)
 
 		HKPLAYERINFO adminPlyr;
 		if (HkGetPlayerInfo(cmds->GetAdminName(), adminPlyr, false) != HKE_OK || adminPlyr.iShip == 0)

--- a/Plugins/Public/pvecontroller/Main.cpp
+++ b/Plugins/Public/pvecontroller/Main.cpp
@@ -455,6 +455,8 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	if (wscCmd.compare(L"pvecontroller"))
 		return false;
 
+	if (!(cmds->rights & RIGHT_PLUGINS)) { cmds->Print(L"ERR No permission\n"); return false; }
+
 	if (!cmds->ArgStrToEnd(1).compare(L"status"))
 	{
 		cmds->Print(L"PVECONTROLLER: PvE Controller (Phase 1) is active.\n");

--- a/Source/FLHook/CCmds.cpp
+++ b/Source/FLHook/CCmds.cpp
@@ -1321,6 +1321,14 @@ void CCmds::SetRightsByString(const string &scRights)
 		rights |= RIGHT_SPECIAL2;
 	if (scRightStr.find("special3") != -1)
 		rights |= RIGHT_SPECIAL3;
+	if (scRightStr.find("chasepull") != -1)
+		rights |= RIGHT_CHASEPULL;
+	if (scRightStr.find("aicontrol") != -1)
+		rights |= RIGHT_AICONTROL;
+	if (scRightStr.find("cloak") != -1)
+		rights |= RIGHT_CLOAK;
+	if (scRightStr.find("bases") != -1)
+		rights |= RIGHT_BASES;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/FLHook/CCmds.h
+++ b/Source/FLHook/CCmds.h
@@ -23,6 +23,10 @@ enum CCMDS_RIGHTS
 	RIGHT_SPECIAL2 = (1 << 12),
 	RIGHT_SPECIAL3 = (1 << 13),
 	RIGHT_KICK = (1 << 14),
+	RIGHT_CHASEPULL = (1 << 15),
+	RIGHT_AICONTROL = (1 << 16),
+	RIGHT_CLOAK = (1 << 17),
+	RIGHT_BASES = (1 << 18),
 };
 
 // class

--- a/Source/FLHookPluginSDK/headers/FLHook.h
+++ b/Source/FLHookPluginSDK/headers/FLHook.h
@@ -587,6 +587,10 @@ enum CCMDS_RIGHTS
 	RIGHT_SPECIAL2 = (1 << 12),
 	RIGHT_SPECIAL3 = (1 << 13),
 	RIGHT_KICK = (1 << 14),
+	RIGHT_CHASEPULL = (1 << 15),
+	RIGHT_AICONTROL = (1 << 16),
+	RIGHT_CLOAK = (1 << 17),
+	RIGHT_BASES = (1 << 18),
 };
 
 class CTimer


### PR DESCRIPTION
feat(set_admin): adds four new subgroups to set admin command

setadmin PlayerName chasepull, which allows
```
chase
pull
```
setadmin PlayerName aicontrol, which allows
```
aidestroy
aicancel
aifollow
aicome
aifleet
fleetlist
```
setadmin PlayerName cloak, which allows
```
cloak
```
setadmin PlayerName bases, which allows
```
testrecipe
testdeploy
basedestroy
basetogglegod
testbase
jumpcreate
basecreate
basedebugon
basedebugoff
```
Additionally:
locked commands in pvecontroller to be under
setadmin PlayerName plugins
```
pvecontroller <command>
```
and some weird commands from player_restrictions
made sure to hide(or rehide) under superadmin rights
```
showrestrictions
generateid
shiptest
healthtest1
healthtest2
testfuseobj
testunfuseobj
testselffuseobj
testselfunfuseobj
```

