### PR TITLE
Base: disabling hostile defense mods

### DIFF
--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -110,6 +110,9 @@ float damage_threshold = 400000;
 //the amount of damage necessary to deal to one base in order to trigger siege status
 float siege_mod_damage_trigger_level = 4000000;
 
+//the distance between bases to share siege mod activation
+float siege_mod_chain_reaction_trigger_distance = 5000;
+
 uint GetAffliationFromClient(uint client)
 {
 	int rep;
@@ -418,6 +421,10 @@ void LoadSettingsActual()
 						damage_threshold = ini.get_value_float(0);
 					}
 					else if (ini.is_value("siege_mod_damage_trigger_level"))
+					{
+						siege_mod_damage_trigger_level = ini.get_value_float(0);
+					}
+					else if (ini.is_value("siege_mod_chain_reaction_trigger_distance"))
 					{
 						siege_mod_damage_trigger_level = ini.get_value_float(0);
 					}

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -108,10 +108,10 @@ map<uint, wstring> listCommodities;
 float damage_threshold = 400000;
 
 //the amount of damage necessary to deal to one base in order to trigger siege status
-float siege_mod_damage_trigger_level = 4000000;
+float siege_mod_damage_trigger_level = 8000000;
 
 //the distance between bases to share siege mod activation
-float siege_mod_chain_reaction_trigger_distance = 5000;
+float siege_mod_chain_reaction_trigger_distance = 8000;
 
 uint GetAffliationFromClient(uint client)
 {

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1033,6 +1033,30 @@ bool UserCmd_Process(uint client, const wstring &args)
 		PlayerCommands::BaseLstAllyFac(client, args);
 		return true;
 	}
+	else if (args.find(L"/base addhfac") == 0)
+	{
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+		PlayerCommands::BaseAddAllyFac(client, args, true);
+		return true;
+	}
+	else if (args.find(L"/base rmhfac") == 0)
+	{
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+		PlayerCommands::BaseRmAllyFac(client, args, true);
+		return true;
+	}
+	else if (args.find(L"/base clearhfac") == 0)
+	{
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+		PlayerCommands::BaseClearAllyFac(client, args, true);
+		return true;
+	}
+	else if (args.find(L"/base lsthfac") == 0)
+	{
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+		PlayerCommands::BaseLstAllyFac(client, args, true);
+		return true;
+	}
 	else if (args.find(L"/base myfac") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
@@ -1152,11 +1176,17 @@ static bool IsDockingAllowed(PlayerBase *base, uint client)
 		}
 	}
 
-	//Allow dock if player is on the friendly faction list.
 	uint playeraff = GetAffliationFromClient(client);
+	//Do not allow dock if player is on the hostile faction list.
+	if (base->hostile_factions.find(playeraff) != base->hostile_factions.end())
+	{
+		return false;
+	}
+
+	//Allow dock if player is on the friendly faction list.
 	if (base->ally_factions.find(playeraff) != base->ally_factions.end())
 	{
-		return 1.0;
+		return true;
 	}
 
 	// Base allows neutral ships to dock

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -108,10 +108,10 @@ map<uint, wstring> listCommodities;
 float damage_threshold = 400000;
 
 //the amount of damage necessary to deal to one base in order to trigger siege status
-float siege_mod_damage_trigger_level = 8000000;
+float siege_mode_damage_trigger_level = 8000000;
 
 //the distance between bases to share siege mod activation
-float siege_mod_chain_reaction_trigger_distance = 8000;
+float siege_mode_chain_reaction_trigger_distance = 8000;
 
 uint GetAffliationFromClient(uint client)
 {
@@ -420,13 +420,13 @@ void LoadSettingsActual()
 					{
 						damage_threshold = ini.get_value_float(0);
 					}
-					else if (ini.is_value("siege_mod_damage_trigger_level"))
+					else if (ini.is_value("siege_mode_damage_trigger_level"))
 					{
-						siege_mod_damage_trigger_level = ini.get_value_float(0);
+						siege_mode_damage_trigger_level = ini.get_value_float(0);
 					}
-					else if (ini.is_value("siege_mod_chain_reaction_trigger_distance"))
+					else if (ini.is_value("siege_mode_chain_reaction_trigger_distance"))
 					{
-						siege_mod_damage_trigger_level = ini.get_value_float(0);
+						siege_mode_damage_trigger_level = ini.get_value_float(0);
 					}
 					else if (ini.is_value("status_export_type"))
 					{

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -107,6 +107,9 @@ map<uint, wstring> listCommodities;
 //the hostility and weapon platform activation from damage caused by one player
 float damage_threshold = 400000;
 
+//the amount of damage necessary to deal to one base in order to trigger siege status
+float siege_mod_damage_trigger_level = 4000000;
+
 uint GetAffliationFromClient(uint client)
 {
 	int rep;
@@ -413,6 +416,10 @@ void LoadSettingsActual()
 					else if (ini.is_value("damage_threshold"))
 					{
 						damage_threshold = ini.get_value_float(0);
+					}
+					else if (ini.is_value("siege_mod_damage_trigger_level"))
+					{
+						siege_mod_damage_trigger_level = ini.get_value_float(0);
 					}
 					else if (ini.is_value("status_export_type"))
 					{

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -292,6 +292,7 @@ public:
 
 	float GetAttitudeTowardsClient(uint client, bool emulated_siege_mode = false);
 	void SyncReputationForBase();
+	void SiegeModChainReaction();
 	void SyncReputationForBaseObject(uint space_obj);
 
 	float SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints);
@@ -619,4 +620,6 @@ extern const char* MODULE_TYPE_NICKNAMES[13];
 extern float damage_threshold;
 
 extern float siege_mod_damage_trigger_level;
+
+extern float siege_mod_chain_reaction_trigger_distance;
 #endif

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -366,9 +366,6 @@ public:
 	//changes how defense mod act depending on the amount of damage made to base in the last hours
 	bool siege_mode;
 
-	//going over the limit: siege_mod_damage_trigger_level will trigger siege mode ON.
-	float received_by_base_damage;
-
 	// List of allied ship tags.
 	list<wstring> ally_tags;
 

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -290,7 +290,7 @@ public:
 
 	static string CreateBaseNickname(const string &basename);
 
-	float GetAttitudeTowardsClient(uint client);
+	float GetAttitudeTowardsClient(uint client, bool emulated_siege_mode = false);
 	void SyncReputationForBase();
 	void SyncReputationForBaseObject(uint space_obj);
 
@@ -361,6 +361,12 @@ public:
 	// If 1 then base is hostile to all ships unless they are on the ally tag list.
 	// If 2 then base is neutral to all ships and any ship may dock.
 	int defense_mode;
+
+	//changes how defense mod act depending on the amount of damage made to base in the last hours
+	bool siege_mode;
+
+	//going over the limit: siege_mod_damage_trigger_level will trigger siege mode ON.
+	float received_by_base_damage;
 
 	// List of allied ship tags.
 	list<wstring> ally_tags;
@@ -611,4 +617,6 @@ extern string set_status_path_json;
 extern const char* MODULE_TYPE_NICKNAMES[13];
 
 extern float damage_threshold;
+
+extern float siege_mod_damage_trigger_level;
 #endif

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -375,6 +375,9 @@ public:
 	//List of allied factions
 	set<uint> ally_factions;
 
+	//List of hostile factions
+	set<uint> hostile_factions;
+
 	// List of ships that are hostile to this base
 	map<wstring, wstring> hostile_tags;
 	map<wstring, float> hostile_tags_damage;
@@ -510,10 +513,10 @@ namespace PlayerCommands
 	void BaseAddAllyTag(uint client, const wstring &args);
 	void BaseRmAllyTag(uint client, const wstring &args);
 	void BaseLstAllyTag(uint client, const wstring &args);
-	void BaseAddAllyFac(uint client, const wstring &args);
-	void BaseRmAllyFac(uint client, const wstring &args);
-	void BaseClearAllyFac(uint client, const wstring &args);
-	void BaseLstAllyFac(uint client, const wstring &args);
+	void BaseAddAllyFac(uint client, const wstring &args, bool HostileFactionMod = false);
+	void BaseRmAllyFac(uint client, const wstring &args, bool HostileFactionMod = false);
+	void BaseClearAllyFac(uint client, const wstring &args, bool HostileFactionMod = false);
+	void BaseLstAllyFac(uint client, const wstring &args, bool HostileFactionMod = false);
 	void BaseViewMyFac(uint client, const wstring &args);
 	void BaseAddHostileTag(uint client, const wstring &args);
 	void BaseRmHostileTag(uint client, const wstring &args);

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -619,7 +619,7 @@ extern const char* MODULE_TYPE_NICKNAMES[13];
 
 extern float damage_threshold;
 
-extern float siege_mod_damage_trigger_level;
+extern float siege_mode_damage_trigger_level;
 
-extern float siege_mod_chain_reaction_trigger_distance;
+extern float siege_mode_chain_reaction_trigger_distance;
 #endif

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -292,7 +292,7 @@ public:
 
 	float GetAttitudeTowardsClient(uint client, bool emulated_siege_mode = false);
 	void SyncReputationForBase();
-	void SiegeModChainReaction();
+	void SiegeModChainReaction(uint client);
 	void SyncReputationForBaseObject(uint space_obj);
 
 	float SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints);

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -287,6 +287,10 @@ void PlayerBase::Load()
 					{
 						ally_factions.insert(ini.get_value_int(0));
 					}
+					else if (ini.is_value("faction_hostile_tag"))
+					{
+						hostile_factions.insert(ini.get_value_int(0));
+					}
 					else if (ini.is_value("passwd"))
 					{
 						wstring passwd;
@@ -403,6 +407,10 @@ void PlayerBase::Save()
 		for(auto i : ally_factions)
 		{
 			fprintf(file, "faction_ally_tag = %d\n", i);
+		}
+		for (auto i : hostile_factions)
+		{
+			fprintf(file, "faction_hostile_tag = %d\n", i);
 		}
 		for (map<wstring, wstring>::iterator i = hostile_tags.begin();
 			i != hostile_tags.end(); ++i)
@@ -548,12 +556,11 @@ float PlayerBase::GetAttitudeTowardsClient(uint client, bool emulated_siege_mode
 	}
 
 	uint playeraff = GetAffliationFromClient(client);
-	// Make base friendly if player is on the friendly faction list.
-	//TODO in second commit
-	/*if ((siege_mode || emulated_siege_mode) && hostile_factions.find(playeraff) != hostile_factions.end())
+	// Make base hostile if player is on the hostile faction list.
+	if ((siege_mode || emulated_siege_mode) && hostile_factions.find(playeraff) != hostile_factions.end())
 	{
 		return -1.0;
-	}*/
+	}
 
 	// Make base friendly if player is on the friendly faction list.
 	if (ally_factions.find(playeraff) != ally_factions.end())

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -609,6 +609,24 @@ void PlayerBase::SyncReputationForBase()
 	}
 }
 
+// For all players in the base's system, resync their reps towards all objects
+// of this base.
+void PlayerBase::SiegeModChainReaction()
+{
+	map<uint, PlayerBase*>::iterator it;
+	for (it = player_bases.begin(); it != player_bases.end(); it++)
+	{
+		if (it->second->system == this->system)
+		{
+			if (HkDistance3D(it->second->position, this->position) < siege_mod_chain_reaction_trigger_distance)
+			{
+				it->second->siege_mode = true;
+				it->second->SyncReputationForBase();
+			}
+		}
+	}
+}
+
 // For all players in the base's system, resync their reps towards this object.
 void PlayerBase::SyncReputationForBaseObject(uint space_obj)
 {
@@ -707,6 +725,9 @@ float PlayerBase::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 					ReportAttack(this->basename, charname, this->system, L"activated self-defense against");
 
 					SyncReputationForBase();
+
+					if (siege_mode)
+						SiegeModChainReaction();
 				}
 			}
 		}
@@ -721,7 +742,7 @@ float PlayerBase::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 				ReportAttack(this->basename, charname, this->system, L"is triggered to siege mod by");
 
 				siege_mode = true;
-				SyncReputationForBase();
+				SiegeModChainReaction();
 			}
 		}
 	}

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -550,7 +550,7 @@ float PlayerBase::GetAttitudeTowardsClient(uint client, bool emulated_siege_mode
 	}
 
 	// Make base hostile if player is on the hostile list.
-	if (hostile_tags.find(charname) != hostile_tags.end())
+	if (!emulated_siege_mode && hostile_tags.find(charname) != hostile_tags.end())
 	{
 		return -1.0;
 	}
@@ -664,12 +664,16 @@ void PlayerBase::SiegeModChainReaction(uint client)
 			{
 				if (!(it->second->siege_mode))
 				{
-					it->second->siege_mode = true;
+					float attitude = it->second->GetAttitudeTowardsClient(client, true);
+					if (attitude < -0.55f)
+					{
+						it->second->siege_mode = true;
 
-					const wstring& charname = (const wchar_t*)Players.GetActiveCharacterName(client);
-					ReportAttack(it->second->basename, charname, it->second->system, L"siege mode triggered by");
+						const wstring& charname = (const wchar_t*)Players.GetActiveCharacterName(client);
+						ReportAttack(it->second->basename, charname, it->second->system, L"has detected hostile activity at the nearby base by");
 
-					it->second->SyncReputationForBase();
+						it->second->SyncReputationForBase();
+					}
 				}
 			}
 		}

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -44,10 +44,6 @@ namespace PlayerCommands
 			L"<TRA bold=\"true\"/><TEXT>/base addtag [tag], /base rmtag [tag], /base lsttag</TEXT><TRA bold=\"false\"/><PARA/>"
 			L"<TEXT>Add, remove and list ally tags for the base.</TEXT><PARA/><PARA/>"
 
-
-			L"<TRA bold=\"true\"/><TEXT>/base addfac [aff tag], /base rmfac [aff tag], /base lstfac, /base myfac</TEXT><TRA bold=\"false\"/><PARA/>"
-			L"<TEXT>Add, remove and list ally factions for the base. Show your affiliation ID and all available.</TEXT><PARA/><PARA/>"
-
 			L"<TRA bold=\"true\"/><TEXT>/base addhostile [tag], /base rmhostile [tag], /base lsthostile</TEXT><TRA bold=\"false\"/><PARA/>"
 			L"<TEXT>Add, remove and list blacklisted tags for the base. They will be shot on sight so use complete tags like =LSF= or IMG| or a shipname like Crunchy_Salad.</TEXT><PARA/><PARA/>"
 
@@ -97,6 +93,12 @@ namespace PlayerCommands
 
 			L"<TRA bold=\"true\"/><TEXT>/base shieldmod</TEXT><TRA bold=\"false\"/><PARA/>"
 			L"<TEXT>Control shield modules.</TEXT><PARA/><PARA/>"
+
+			L"<TRA bold=\"true\"/><TEXT>/base addfac [aff tag], /base rmfac [aff tag], /base lstfac, /base myfac</TEXT><TRA bold=\"false\"/><PARA/>"
+			L"<TEXT>Add, remove and list ally factions for the base. Show your affiliation ID and all available.</TEXT><PARA/><PARA/>"
+
+			L"<TRA bold=\"true\"/><TEXT>/base addhfac [aff tag], /base rmhfac [aff tag], /base lsthfac</TEXT><TRA bold=\"false\"/><PARA/>"
+			L"<TEXT>Add, remove and list hostile factions for the base.</TEXT><PARA/><PARA/>"
 
 			L"<TRA bold=\"true\"/><TEXT>/base buildmod</TEXT><TRA bold=\"false\"/><PARA/>"
 			L"<TEXT>Control the construction and destruction of base modules and upgrades.</TEXT>";
@@ -517,10 +519,15 @@ namespace PlayerCommands
 		return false;
 	}
 
-	void BaseAddAllyFac(uint client, const wstring &args)
+	void BaseAddAllyFac(uint client, const wstring &args, bool HostileFactionMod)
 	{
 		PlayerBase *base = GetPlayerBaseForClient(client);
 		if (CheckForBase(base, client)) return;
+
+		set<uint>* list;
+		if (!HostileFactionMod)
+			list = &(base->ally_factions);
+		else list = &(base->hostile_factions);
 
 		int tag = 0;
 		try
@@ -533,7 +540,7 @@ namespace PlayerCommands
 			return;
 		}
 
-		if (base->ally_factions.find(tag) != base->ally_factions.end())
+		if ((*list).find(tag) != (*list).end())
 		{
 			PrintUserCmdText(client, L"ERR Tag already exists");
 			return;
@@ -545,25 +552,36 @@ namespace PlayerCommands
 			PrintUserCmdText(client, L"ERR Undefined faction");
 			return;
 		}
-		base->ally_factions.insert(tag);
+		(*list).insert(tag);
 
 		base->Save();
 		PrintUserCmdText(client, L"OK");
 	}
 
-	void BaseClearAllyFac(uint client, const wstring &args)
+	void BaseClearAllyFac(uint client, const wstring &args, bool HostileFactionMod)
 	{
 		PlayerBase *base = GetPlayerBaseForClient(client);
 		if (CheckForBase(base, client)) return;
-		base->ally_factions.clear();
+
+		set<uint>* list;
+		if (!HostileFactionMod)
+			list = &(base->ally_factions);
+		else list = &(base->hostile_factions);
+
+		(*list).clear();
 		base->Save();
 		PrintUserCmdText(client, L"OK");
 	}
 
-	void BaseRmAllyFac(uint client, const wstring &args)
+	void BaseRmAllyFac(uint client, const wstring &args, bool HostileFactionMod)
 	{
 		PlayerBase *base = GetPlayerBaseForClient(client);
 		if (CheckForBase(base, client)) return;
+
+		set<uint>* list;
+		if (!HostileFactionMod)
+			list = &(base->ally_factions);
+		else list = &(base->hostile_factions);
 
 		uint tag = 0;
 		try
@@ -576,13 +594,13 @@ namespace PlayerCommands
 			return;
 		}
 
-		if (base->ally_factions.find(tag) == base->ally_factions.end())
+		if ((*list).find(tag) == (*list).end())
 		{
 			PrintUserCmdText(client, L"ERR Tag does not exist");
 			return;
 		}
 
-		base->ally_factions.erase(tag);
+		(*list).erase(tag);
 		base->Save();
 		PrintUserCmdText(client, L"OK");
 	}
@@ -709,12 +727,17 @@ namespace PlayerCommands
 	Affiliations A;
 	void Aff_initer() { A.Init(); };
 
-	void BaseLstAllyFac(uint client, const wstring &cmd)
+	void BaseLstAllyFac(uint client, const wstring &cmd, bool HostileFactionMod)
 	{
 		PlayerBase *base = GetPlayerBaseForClient(client);
 		if (CheckForBase(base, client)) return;
 
-		for (set<uint>::iterator it = base->ally_factions.begin(); it != base->ally_factions.end(); ++it)
+		set<uint>* list;
+		if (!HostileFactionMod)
+			list = &(base->ally_factions);
+		else list = &(base->hostile_factions);
+
+		for (set<uint>::iterator it = (*list).begin(); it != (*list).end(); ++it)
 		{
 			A.FindAndPrintOneAffiliation(client, *it);
 		}

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -525,8 +525,7 @@ namespace PlayerCommands
 		if (CheckForBase(base, client)) return;
 
 		set<uint>* list;
-		if (!HostileFactionMod)
-			list = &(base->ally_factions);
+		if (!HostileFactionMod) list = &(base->ally_factions);
 		else list = &(base->hostile_factions);
 
 		int tag = 0;
@@ -564,8 +563,7 @@ namespace PlayerCommands
 		if (CheckForBase(base, client)) return;
 
 		set<uint>* list;
-		if (!HostileFactionMod)
-			list = &(base->ally_factions);
+		if (!HostileFactionMod) list = &(base->ally_factions);
 		else list = &(base->hostile_factions);
 
 		(*list).clear();
@@ -579,8 +577,7 @@ namespace PlayerCommands
 		if (CheckForBase(base, client)) return;
 
 		set<uint>* list;
-		if (!HostileFactionMod)
-			list = &(base->ally_factions);
+		if (!HostileFactionMod) list = &(base->ally_factions);
 		else list = &(base->hostile_factions);
 
 		uint tag = 0;
@@ -733,8 +730,7 @@ namespace PlayerCommands
 		if (CheckForBase(base, client)) return;
 
 		set<uint>* list;
-		if (!HostileFactionMod)
-			list = &(base->ally_factions);
+		if (!HostileFactionMod) list = &(base->ally_factions);
 		else list = &(base->hostile_factions);
 
 		for (set<uint>::iterator it = (*list).begin(); it != (*list).end(); ++it)


### PR DESCRIPTION
## new features:

- https://github.com/DiscoveryGC/FLHook/pull/158/commits/e785615c17de4bec1de6e5e4569f236054be3aa9 - hostile defense mods were locked under 'siege mod', which requires for base to receive 8 million damage for its activation. The bases will not attack everyone by default any longer, only if they were triggered to siege mode. Defense mods continue to fulfill nodock regulation role. Their role to identify hostiles is still important during activated siege mode.
- https://github.com/DiscoveryGC/FLHook/pull/158/commits/957fdd06cd00587b0264863bfb290904b32cd310 Chain reaction = activation of siege mode to one base, activates siege mods to nearby bases as well (within 8k range as the default value)
- https://github.com/DiscoveryGC/FLHook/pull/158/commits/a759c4f86ebe5a1b1a627e61942bbdef535a92e4 nearby bases get activated siege mod in chain reaction, only if they are hostile in 'emulated siege mode' to at least one of the attacker. Basically, check for reputation.
- https://github.com/DiscoveryGC/FLHook/pull/158/commits/50e15afc6d4955659e309db50be3f61abdcd2e82 duplicated white list IFF lists for bases to have its blacklist IFF version in order having better way, which IFFs are enemies to the current base + it regulates nodock blacklist for the base
New commands were added to the change
1. /base addhfac `<IFF group> `// adds IFF to hostile base list
2. /base rmhfac `<IFF group>` // removes IFF from hostile base list
3. /base clearhfac // clears IFF hostile list

- https://github.com/DiscoveryGC/FLHook/pull/158/commits/2c7f3515d06175494eb08e4396c50017bba3addd added system-wide + logger warnings to players and admins for chain reacted siege mods activations (similar messages were added in previous commits for activation of siege mode of the targeted base, and for activation of personal self-defense against one player)
- https://github.com/DiscoveryGC/FLHook/pull/158/commits/5e3d1502504401e7858aa1472d7dc62aa7004ad4 improved siege mode trigger condition
instead of 8 million sum of damage by all players, the damage must be made by ONE particular person
in this it will be more abuse proof and will help better to justify rule enforcing against triggering siege mods

## fixes:
- replaced return 1.0 to return true, in nodock regulating function, which I left by accident in a previous pull request.
- SpaceObjDamaged had been activating SyncReputationForBase too often due to a previous PR, fixed to be activated only once when necessary.

## API:

### base.cfg
siege_mod_damage_trigger_level = 8000000
siege_mod_chain_reaction_trigger_distance = 8000

## why it should be accepted:

- https://discoverygc.com/forums/showthread.php?tid=183525 original discussion (heavily outdated due to super inefficiency proposed implementation)
- discord votings: (some of the people aren't mentioned, but balance people kicked me to do it the last days about it, Haste and Pillow)
https://discord.com/channels/444137064439742474/698718138145046538/800011282170380288
![image](https://user-images.githubusercontent.com/20555918/112734124-7c583300-8f76-11eb-9826-c097d78e337c.png)
![image](https://user-images.githubusercontent.com/20555918/112734144-8da13f80-8f76-11eb-9e4c-c61d0c07a77b.png)
- [also made a survey](https://discoverygc.com/forums/showthread.php?tid=186087) about it among players, more than half of players wish for it. but almost half of players do not wish it.
- The balance devs would make the change to remove 'PoB area domination(which shoots all hostiles)' anyway, but in a much more crude way. 

## notes:

- After consideration that, more than half of players wish it, all developers except one voted yes, and plus I think it is a good change as well, I decided it should be made. And balance people would do something drastic like removing weapon platforms if not having this code addition, I thought it would be better to have it made in a more elegant solution in my opinion.
- built dlls to test in https://github.com/dd84ai/FLHook/releases/tag/1.1.1
- Game masters could make a new rule, that invoking siege mod trigger without attack declaration leads to sanctions, for example:
![image](https://user-images.githubusercontent.com/20555918/112745465-d25ac400-8fd2-11eb-8daa-9406cdb5ca86.png)
This messaged is logged in playerbase_events.log
- this pull request
Fixes #157 , information inside the issue is outdated