### PR TITLE
Feature: Added Buy/Sell Functionality

### DIFF
--- a/Plugins/Public/base_plugin/ClientCommands.cpp
+++ b/Plugins/Public/base_plugin/ClientCommands.cpp
@@ -38,14 +38,14 @@ void SendMarketGoodUpdated(PlayerBase *base, uint good, MARKET_ITEM &item)
 				if (item.quantity == 0)
 				{
 					_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-						base->proxy_base, good, item.price, 1, 0);
+						base->proxy_base, good, item.buyprice, 1, 0);
 				}
 				// If the item is buy only and this is not an admin then it is
 				// buy only at the client
 				else if (item.min_stock >= item.quantity && !clients[client].admin)
 				{
 					_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-						base->proxy_base, good, item.price, 1, 0);
+						base->proxy_base, good, item.buyprice, 1, 0);
 				}
 				// Otherwise this item is for sale by the client.
 				else
@@ -80,14 +80,14 @@ void SendMarketGoodSync(PlayerBase *base, uint client)
 		if (item.quantity == 0)
 		{
 			_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-				base->proxy_base, good, item.price, 1, 0);
+				base->proxy_base, good, item.buyprice, 1, 0);
 		}
 		// If the item is buy only and this is not an admin then it is
 		// buy only at the client
 		else if (item.min_stock >= item.quantity && !clients[client].admin)
 		{
 			_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-				base->proxy_base, good, item.price, 1, 0);
+				base->proxy_base, good, item.buyprice, 1, 0);
 		}
 		// Otherwise this item is for sale by the client.
 		else

--- a/Plugins/Public/base_plugin/ClientCommands.cpp
+++ b/Plugins/Public/base_plugin/ClientCommands.cpp
@@ -38,20 +38,20 @@ void SendMarketGoodUpdated(PlayerBase *base, uint good, MARKET_ITEM &item)
 				if (item.quantity == 0)
 				{
 					_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-						base->proxy_base, good, item.buyprice, 1, 0);
+						base->proxy_base, good, item.buyprice, 2, 0);
 				}
 				// If the item is buy only and this is not an admin then it is
 				// buy only at the client
 				else if (item.min_stock >= item.quantity && !clients[client].admin)
 				{
 					_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-						base->proxy_base, good, item.buyprice, 1, 0);
+						base->proxy_base, good, item.buyprice, 2, 0);
 				}
 				// Otherwise this item is for sale by the client.
 				else
 				{
 					_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-						base->proxy_base, good, item.sellprice, 0, item.quantity);
+						base->proxy_base, good, item.sellprice, 2, item.quantity);
 				}
 				SendCommand(client, buf);
 			}
@@ -68,7 +68,7 @@ void SendMarketGoodSync(PlayerBase *base, uint client)
 	// Send a dummy entry if there are no goods at this base
 	if (!base->market_items.size())
 		SendCommand(client, L" SetMarketOverride 0 0 0 0");
-
+	
 	// Send the market
 	for (map<uint, MARKET_ITEM>::iterator i = base->market_items.begin();
 		i != base->market_items.end(); i++)
@@ -80,22 +80,24 @@ void SendMarketGoodSync(PlayerBase *base, uint client)
 		if (item.quantity == 0)
 		{
 			_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-				base->proxy_base, good, item.buyprice, 1, 0);
+				base->proxy_base, good, item.buyprice, 2, 0);
 		}
 		// If the item is buy only and this is not an admin then it is
 		// buy only at the client
 		else if (item.min_stock >= item.quantity && !clients[client].admin)
 		{
 			_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-				base->proxy_base, good, item.buyprice, 1, 0);
+				base->proxy_base, good, item.buyprice, 2, 0);
 		}
 		// Otherwise this item is for sale by the client.
 		else
 		{
 			_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-				base->proxy_base, good, item.sellprice, 0, item.quantity);
+				base->proxy_base, good, item.sellprice, 2, item.quantity);
 		}
+			
 		SendCommand(client, buf);
+		
 	}
 }
 

--- a/Plugins/Public/base_plugin/ClientCommands.cpp
+++ b/Plugins/Public/base_plugin/ClientCommands.cpp
@@ -51,7 +51,7 @@ void SendMarketGoodUpdated(PlayerBase *base, uint good, MARKET_ITEM &item)
 				else
 				{
 					_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-						base->proxy_base, good, item.price, 0, item.quantity);
+						base->proxy_base, good, item.sellprice, 0, item.quantity);
 				}
 				SendCommand(client, buf);
 			}
@@ -93,7 +93,7 @@ void SendMarketGoodSync(PlayerBase *base, uint client)
 		else
 		{
 			_snwprintf(buf, sizeof(buf), L" SetMarketOverride %u %u %f %u %u",
-				base->proxy_base, good, item.price, 0, item.quantity);
+				base->proxy_base, good, item.sellprice, 0, item.quantity);
 		}
 		SendCommand(client, buf);
 	}

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1412,6 +1412,7 @@ void __stdcall BaseEnter(uint base, uint client)
 			// Reset the commodity list	and send a dummy entry if there are no
 			// commodities in the market
 			SaveDockState(client);
+			PlayerCommands::BaseMarketDisclaimer(client);
 			SendMarketGoodSync(base, client);
 			SendBaseStatus(client, base);
 			return;
@@ -1564,7 +1565,7 @@ void __stdcall GFGoodSell(struct SGFGoodSellInfo const &gsi, unsigned int client
 		if (base->market_items.find(gsi.iArchID) == base->market_items.end()
 			&& !clients[client].admin)
 		{
-			PrintUserCmdText(client, L"ERR: Base will not accept goods");
+			PrintUserCmdText(client, L"ERR: Base does not deal in these goods right now");
 			clients[client].reverse_sell = true;
 			return;
 		}

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1108,6 +1108,12 @@ bool UserCmd_Process(uint client, const wstring &args)
 		PlayerCommands::Shop(client, args);
 		return true;
 	}
+	else if (args.find(L"/price") == 0)
+	{
+	returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+	PlayerCommands::PriceView(client, args);
+	return true;
+	}
 	else if (args.find(L"/bank") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
@@ -1567,6 +1573,7 @@ void __stdcall GFGoodSell(struct SGFGoodSellInfo const &gsi, unsigned int client
 
 		uint count = gsi.iCount;
 		int price = (int)item.price * count;
+		int sellprice = (int)item.sellprice * count;
 
 		// base money check //
 		if (count > ULONG_MAX / item.price)
@@ -1758,6 +1765,7 @@ void __stdcall GFGoodBuy(struct SGFGoodBuyInfo const &gbi, unsigned int client)
 			count = base->market_items[gbi.iGoodID].quantity;
 
 		int price = (int)base->market_items[gbi.iGoodID].price * count;
+		int sellprice = (int)base->market_items[gbi.iGoodID].sellprice * count;
 		int curr_money;
 		pub::Player::InspectCash(client, curr_money);
 
@@ -1784,8 +1792,8 @@ void __stdcall GFGoodBuy(struct SGFGoodBuyInfo const &gbi, unsigned int client)
 
 		clients[client].stop_buy = false;
 		base->RemoveMarketGood(gbi.iGoodID, count);
-		pub::Player::AdjustCash(client, 0 - price);
-		base->ChangeMoney(price);
+		pub::Player::AdjustCash(client, 0 - sellprice);
+		base->ChangeMoney(sellprice);
 		base->Save();
 
 		//build string and log the purchase

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -49,13 +49,14 @@ struct ARCHTYPE_STRUCT
 
 struct MARKET_ITEM
 {
-	MARKET_ITEM() : quantity(0), price(1.0f), min_stock(100000), max_stock(100000) {}
+	MARKET_ITEM() : quantity(0), price(1.0f), min_stock(100000), max_stock(100000), sellprice (5.0f) {}
 
 	// Number of units of commodity stored in this base
 	uint quantity;
 
 	// Buy/Sell price for commodity.
 	float price;
+	float sellprice;
 
 	// Stop selling if the base holds less than this number of items
 	uint min_stock;
@@ -528,6 +529,7 @@ namespace PlayerCommands
 	void BaseShieldMod(uint client, const wstring &args);
 	void Bank(uint client, const wstring &args);
 	void Shop(uint client, const wstring &args);
+	void PriceView(uint client, const wstring& args);
 
 	void BaseDeploy(uint client, const wstring &args);
 

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -49,13 +49,13 @@ struct ARCHTYPE_STRUCT
 
 struct MARKET_ITEM
 {
-	MARKET_ITEM() : quantity(0), price(1.0f), min_stock(100000), max_stock(100000), sellprice (5.0f) {}
+	MARKET_ITEM() : quantity(0), buyprice(1.0f), min_stock(100000), max_stock(100000), sellprice (5.0f) {}
 
 	// Number of units of commodity stored in this base
 	uint quantity;
 
 	// Buy/Sell price for commodity.
-	float price;
+	float buyprice;
 	float sellprice;
 
 	// Stop selling if the base holds less than this number of items

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -530,6 +530,7 @@ namespace PlayerCommands
 	void Bank(uint client, const wstring &args);
 	void Shop(uint client, const wstring &args);
 	void PriceView(uint client, const wstring& args);
+	void BaseMarketDisclaimer(uint client);
 
 	void BaseDeploy(uint client, const wstring &args);
 

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -246,14 +246,14 @@ void PlayerBase::Load()
 						MARKET_ITEM mi;
 						UINT good = ini.get_value_int(0);
 						mi.quantity = ini.get_value_int(1);
-						mi.price = ini.get_value_float(2);
+						mi.buyprice = ini.get_value_float(2);
 						mi.min_stock = ini.get_value_int(3);
 						mi.max_stock = ini.get_value_int(4);
 						mi.sellprice = ini.get_value_float(5);
 						//this prevents client crashes for null values in the sell field when we
 						//first load the server after adding sell functionality.
 						if (mi.sellprice == 0) {
-							mi.sellprice = mi.price;
+							mi.sellprice = mi.buyprice;
 						}
 						market_items[good] = mi;
 					}
@@ -402,7 +402,7 @@ void PlayerBase::Save()
 			i != market_items.end(); ++i)
 		{
 			fprintf(file, "commodity = %u, %u, %f, %u, %u, %f\n",
-				i->first, i->second.quantity, i->second.price, i->second.min_stock, i->second.max_stock, i->second.sellprice);
+				i->first, i->second.quantity, i->second.buyprice, i->second.min_stock, i->second.max_stock, i->second.sellprice);
 		}
 
 		fprintf(file, "defensemode = %u\n", defense_mode);

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -249,6 +249,12 @@ void PlayerBase::Load()
 						mi.price = ini.get_value_float(2);
 						mi.min_stock = ini.get_value_int(3);
 						mi.max_stock = ini.get_value_int(4);
+						mi.sellprice = ini.get_value_float(5);
+						//this prevents client crashes for null values in the sell field when we
+						//first load the server after adding sell functionality.
+						if (mi.sellprice == 0) {
+							mi.sellprice = mi.price;
+						}
 						market_items[good] = mi;
 					}
 					else if (ini.is_value("health"))
@@ -395,8 +401,8 @@ void PlayerBase::Save()
 		for (map<UINT, MARKET_ITEM>::iterator i = market_items.begin();
 			i != market_items.end(); ++i)
 		{
-			fprintf(file, "commodity = %u, %u, %f, %u, %u\n",
-				i->first, i->second.quantity, i->second.price, i->second.min_stock, i->second.max_stock);
+			fprintf(file, "commodity = %u, %u, %f, %u, %u, %f\n",
+				i->first, i->second.quantity, i->second.price, i->second.min_stock, i->second.max_stock, i->second.sellprice);
 		}
 
 		fprintf(file, "defensemode = %u\n", defense_mode);

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -1898,6 +1898,52 @@ namespace PlayerCommands
 		}
 	}
 
+	void BaseMarketDisclaimer(uint client)
+	{
+
+		PlayerBase* base = GetPlayerBaseForClient(client);
+		if (!base)
+		{
+			PrintUserCmdText(client, L"ERR Not in player base");
+			return;
+		}
+
+		const uint numPages = 1;
+		wstring pages[numPages];
+		pages[0] = L"<TRA bold=\"true\"/><TEXT>Market Functionality Disclaimer:</TEXT><TRA bold=\"false\"/><PARA/>"
+			L"<TEXT>We have added the functionality for player bases to have both \"buy\" and \"sell\" prices.</TEXT><PARA/>"
+			L"<TEXT>However, due to the coding limits within Freelancer, a method of showing 2 different prices in the </TEXT>"
+			L"<TEXT>dealer/trader window has not been found to work in a way that rules out all potential problems.</TEXT><PARA/><PARA/>"
+
+			L"<TEXT>Therefore, the player inventory in the market will show no value until you select whether you wish to see </TEXT>"
+			L"<TEXT>either the bases \"buy\" price (what the base buys from you for), or the bases \"sell\" price (what the base sells to you for)</TEXT><PARA/><PARA/>"
+
+			L"<TRA bold=\"true\"/><TEXT>/price [buy]/[sell] </TEXT><TRA bold=\"false\"/><PARA/>"
+			L"<TEXT>Change the dealer view to see what the base is currently buying an item for (/price buy)"
+			L" or what the base is selling an item for (/price sell).</TEXT>";
+
+		wstring pagetext = pages[0];
+
+		wchar_t titleBuf[4000];
+		_snwprintf(titleBuf, sizeof(titleBuf), L"Market Disclaimer");
+
+		wchar_t buf[4000];
+		_snwprintf(buf, sizeof(buf), L"<RDL><PUSH/>%s<POP/></RDL>", pagetext);
+
+		HkChangeIDSString(client, 500000, titleBuf);
+		HkChangeIDSString(client, 500001, buf);
+
+		FmtStr caption(0, 0);
+		caption.begin_mad_lib(500000);
+		caption.end_mad_lib();
+
+		FmtStr message(0, 0);
+		message.begin_mad_lib(500001);
+		message.end_mad_lib();
+
+		pub::Player::PopUpDialog(client, caption, message, POPUPDIALOG_BUTTONS_CENTER_OK);
+	}
+
 	void BaseDeploy(uint client, const wstring &args)
 	{
 		if (set_holiday_mode)


### PR DESCRIPTION
**Feature: Added Buy/Sell Functionality**
Added sellprice variable to handle the logic and updated the transaction code to accomplish.
Freelancer only supports one value displayed in dealer menu's however, so the /price command was added. 
Available to all visitors of the base, the /price buy changes the prices displayed in the menu to what the base is buying from players for, /price sell changes it to what the base is selling for. There is condition statements in place to not reveal all items listed in the /shop menu when the /price commands are used
Also changed dealer view logic to display what the base buys the item for if the item you have is out of stock on the base, otherwise by default, prices shown are what the base sells the item for.

_/base help menus updated with feature info_