### PR TITLE
Siege Rework

### DIFF
--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -356,6 +356,8 @@ void CoreModule::Spawn()
 			base->base_health = base->max_base_health;
 		pub::SpaceObj::SetRelativeHealth(space_obj, base->base_health / base->max_base_health);
 
+		base_shield_reinforcement_threshold = shield_reinforcement_threshold_flat + (shield_reinforcement_threshold_percent * base->max_base_health);
+
 		base->SyncReputationForBaseObject(space_obj);
 		if (set_plugin_debug > 1)
 			ConPrint(L"CoreModule::created space_obj=%u health=%f\n", space_obj, base->base_health);
@@ -600,8 +602,8 @@ float CoreModule::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 
 inline void CoreModule::AddDmgTakenToThresholdCounterAndReinforceShield(float dmgTaken) {
 	damage_taken_since_last_threshold += dmgTaken;
-	if (damage_taken_since_last_threshold >= shield_reinforcement_threshold) {
-		damage_taken_since_last_threshold -= shield_reinforcement_threshold;
+	if (damage_taken_since_last_threshold >= base_shield_reinforcement_threshold) {
+		damage_taken_since_last_threshold -= base_shield_reinforcement_threshold;
 		shield_strength_multiplier += shield_reinforcement_increment;
 	}
 }

--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -582,7 +582,7 @@ float CoreModule::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 		return curr_hitpoints;
 	}
 
-	if (base->shield_state != PlayerBase::SHIELD_STATE_OFFLINE && shield_strength_multiplier < 1.0 && true == globalBaseVulnerabilityStatus && base->invulnerable == 0)
+	if (base->shield_state != PlayerBase::SHIELD_STATE_OFFLINE && shield_strength_multiplier < 1.0 && !isGlobalBaseInvulnerabilityActive && base->invulnerable == 0)
 	{
 		float damageTaken = ((curr_hitpoints - new_hitpoints) * (1 - shield_strength_multiplier));
 		AddDmgTakenToThresholdCounterAndReinforceShield(damageTaken);

--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -356,7 +356,10 @@ void CoreModule::Spawn()
 			base->base_health = base->max_base_health;
 		pub::SpaceObj::SetRelativeHealth(space_obj, base->base_health / base->max_base_health);
 
-		base_shield_reinforcement_threshold = shield_reinforcement_threshold_flat + (shield_reinforcement_threshold_percent * base->max_base_health);
+		if (shield_reinforcement_threshold_map.count(base->base_level))
+			base_shield_reinforcement_threshold = shield_reinforcement_threshold_map[base->base_level];
+		else
+			base_shield_reinforcement_threshold = 0.0f;
 
 		base->SyncReputationForBaseObject(space_obj);
 		if (set_plugin_debug > 1)
@@ -585,7 +588,13 @@ float CoreModule::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 	if (base->shield_state != PlayerBase::SHIELD_STATE_OFFLINE && shield_strength_multiplier < 1.0 && !isGlobalBaseInvulnerabilityActive && base->invulnerable == 0)
 	{
 		float damageTaken = ((curr_hitpoints - new_hitpoints) * (1 - shield_strength_multiplier));
-		AddDmgTakenToThresholdCounterAndReinforceShield(damageTaken);
+
+		damage_taken_since_last_threshold += damageTaken;
+		if (damage_taken_since_last_threshold >= base_shield_reinforcement_threshold) {
+			damage_taken_since_last_threshold -= base_shield_reinforcement_threshold;
+			shield_strength_multiplier += shield_reinforcement_increment;
+		}
+
 		return curr_hitpoints - damageTaken;
 	}
 	else
@@ -594,14 +603,6 @@ float CoreModule::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 	}
 
 	return 0.0f;
-}
-
-inline void CoreModule::AddDmgTakenToThresholdCounterAndReinforceShield(float dmgTaken) {
-	damage_taken_since_last_threshold += dmgTaken;
-	if (damage_taken_since_last_threshold >= base_shield_reinforcement_threshold) {
-		damage_taken_since_last_threshold -= base_shield_reinforcement_threshold;
-		shield_strength_multiplier += shield_reinforcement_increment;
-	}
 }
 
 bool CoreModule::SpaceObjDestroyed(uint space_obj)

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -94,10 +94,10 @@ uint repair_per_repair_cycle = 60000;
 // set of configurable variables defining the diminishing returns on damage during POB siege
 // POB starts at base_shield_strength, then every 'threshold' of damage taken, 
 // shield goes up in absorption by the 'increment'
-float shield_reinforcement_threshold_flat;
-float shield_reinforcement_threshold_percent;
-float shield_reinforcement_increment;
-float base_shield_strength;
+float shield_reinforcement_threshold_flat = 1000000.0f;
+float shield_reinforcement_threshold_percent = 0.0f;
+float shield_reinforcement_increment = 0.0f;
+float base_shield_strength = 0.97f;
 
 // decides if bases are globally immune, based on server time
 bool isGlobalBaseInvulnerabilityActive;
@@ -2796,6 +2796,11 @@ void ResetShieldStrength() {
 }
 
 bool checkBaseVulnerabilityStatus() {
+
+	if (baseVulnerabilityWindows.empty()) {
+		return false;
+	}
+
 	time_t tNow = time(0);
 	struct tm *t = localtime(&tNow);
 	uint currHour = t->tm_hour;

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -87,7 +87,8 @@ uint repair_per_repair_cycle = 60000;
 // set of configurable variables defining the diminishing returns on damage during POB siege
 // POB starts at base_shield_strength, then every 'threshold' of damage taken, 
 // shield goes up in absorption by the 'increment'
-float shield_reinforcement_threshold;
+float shield_reinforcement_threshold_flat;
+float shield_reinforcement_threshold_percent;
 float shield_reinforcement_increment;
 float base_shield_strength;
 
@@ -458,9 +459,13 @@ void LoadSettingsActual()
 					{
 						repair_per_repair_cycle = ini.get_value_int(0);
 					}
-					else if (ini.is_value("shield_reinforcement_threshold"))
+					else if (ini.is_value("shield_reinforcement_threshold_flat"))
 					{
-						shield_reinforcement_threshold = ini.get_value_float(0);
+						shield_reinforcement_threshold_flat = ini.get_value_float(0);
+					}
+					else if (ini.is_value("shield_reinforcement_threshold_percent"))
+					{
+						shield_reinforcement_threshold_percent = ini.get_value_float(0);
 					}
 					else if (ini.is_value("shield_reinforcement_increment"))
 					{

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -2785,12 +2785,14 @@ EXPORT PLUGIN_INFO* Get_PluginInfo()
 	return p_PI;
 }
 
-void ResetShieldStrength() {
+void ResetAllBasesShieldStrength() {
 	for (map<uint, PlayerBase*>::iterator i = player_bases.begin(); i != player_bases.end(); ++i) {
 		i->second->ResetShieldStrength();
 	}
 }
 
+//return value:
+// false = all bases vulnerable, true = invulnerable
 bool checkBaseVulnerabilityStatus() {
 
 	if (baseVulnerabilityWindows.empty()) {
@@ -2802,7 +2804,7 @@ bool checkBaseVulnerabilityStatus() {
 	uint currHour = t->tm_hour;
 	// iterate over configured vulnerability periods to check if we're in one.
 	// - in case of timeStart < timeEnd, eg. 5-10, the base will be vulnerable between 5AM and 10AM.
-	// - in case of timeStart > timeEnd, eg. 23-2, the base will be vulnerable after 11PM and before 2AM, so a period of 3 hours.
+	// - in case of timeStart > timeEnd, eg. 23-2, the base will be vulnerable after 11PM or before 2AM.
 	for (list<BASE_VULNERABILITY_WINDOW>::iterator i = baseVulnerabilityWindows.begin(); i != baseVulnerabilityWindows.end(); ++i){
 		if((i->start < i->end 
 			&& i->start <= currHour && i->end > currHour)
@@ -2810,7 +2812,7 @@ bool checkBaseVulnerabilityStatus() {
 			&& (i->start <= currHour || i->end > currHour))) {
 			// if bases are going vulnerable in this tick, reset their damage resistance to default
 			if (isGlobalBaseInvulnerabilityActive) {
-				ResetShieldStrength();
+				ResetAllBasesShieldStrength();
 			}
 			return false;
 		}

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -100,7 +100,7 @@ float shield_reinforcement_increment;
 float base_shield_strength;
 
 // decides if bases are globally immune, based on server time
-bool globalBaseVulnerabilityStatus;
+bool isGlobalBaseInvulnerabilityActive;
 
 list<BASE_VULNERABILITY_WINDOW> baseVulnerabilityWindows;
 
@@ -801,7 +801,7 @@ void HkTimerCheckKick()
 	}
 
 	uint curr_time = (uint)time(0);
-	globalBaseVulnerabilityStatus = checkBaseVulnerabilityStatus();
+	isGlobalBaseInvulnerabilityActive = checkBaseVulnerabilityStatus();
 	map<uint, PlayerBase*>::iterator iter = player_bases.begin();
 	while (iter != player_bases.end())
 	{
@@ -2805,11 +2805,11 @@ bool checkBaseVulnerabilityStatus() {
 		|| (i->start > i->end
 			&& (i->start <= currHour || i->end > currHour))) {
 			// if bases are going vulnerable in this tick, reset their damage resistance to default
-			if (!globalBaseVulnerabilityStatus) {
+			if (isGlobalBaseInvulnerabilityActive) {
 				ResetShieldStrength();
 			}
-			return true;
+			return false;
 		}
 	}
-	return false;
+	return true;
 }

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -125,6 +125,7 @@ public:
 	bool dont_rust;
 
 	float shield_strength_multiplier;
+	float base_shield_reinforcement_threshold;
 	float damage_taken_since_last_threshold;
 
 	// The list of goods and usage of goods per minute for the autosys effect
@@ -616,7 +617,8 @@ extern uint set_tick_time;
 // set of configurable variables defining the diminishing returns on damage during POB siege
 // POB starts at base_shield_strength, then every 'threshold' of damage taken, 
 // shield goes up in absorption by the 'increment'
-extern float shield_reinforcement_threshold;
+extern float shield_reinforcement_threshold_flat;
+extern float shield_reinforcement_threshold_percent;
 extern float shield_reinforcement_increment;
 extern float base_shield_strength;
 

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -632,8 +632,8 @@ extern uint set_tick_time;
 // set of configurable variables defining the diminishing returns on damage during POB siege
 // POB starts at base_shield_strength, then every 'threshold' of damage taken, 
 // shield goes up in absorption by the 'increment'
-extern float shield_reinforcement_threshold_flat;
-extern float shield_reinforcement_threshold_percent;
+// threshold size is to be configured per core level.
+extern map<int, float> shield_reinforcement_threshold_map;
 extern float shield_reinforcement_increment;
 extern float base_shield_strength;
 

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -31,6 +31,10 @@ struct RECIPE
 	uint reqlevel;
 };
 
+struct BASE_VULNERABILITY_WINDOW {
+	uint start;
+	uint end;
+};
 struct ARCHTYPE_STRUCT
 {
 	int logic;
@@ -120,6 +124,9 @@ public:
 	// If true, do not take damage
 	bool dont_rust;
 
+	float shield_strength_multiplier;
+	float damage_taken_since_last_threshold;
+
 	// The list of goods and usage of goods per minute for the autosys effect
 	map<uint, uint> mapAutosysGood;
 
@@ -138,6 +145,7 @@ public:
 	float SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints);
 	bool SpaceObjDestroyed(uint space_obj);
 	void SetReputation(int player_rep, float attitude);
+	void AddDmgTakenToThresholdCounterAndReinforceShield(float dmgTaken);
 
 	void RepairDamage(float max_base_health);
 };
@@ -296,6 +304,7 @@ public:
 	void SyncReputationForBaseObject(uint space_obj);
 
 	float SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints);
+	void ResetShieldStrength();
 
 	// The base nickname
 	string nickname;
@@ -604,8 +613,16 @@ extern uint set_damage_tick_time;
 /// The seconds per tick
 extern uint set_tick_time;
 
-/// If the shield is up then damage to the base is changed by this multiplier.
-extern float set_shield_damage_multiplier;
+// set of configurable variables defining the diminishing returns on damage during POB siege
+// POB starts at base_shield_strength, then every 'threshold' of damage taken, 
+// shield goes up in absorption by the 'increment'
+extern float shield_reinforcement_threshold;
+extern float shield_reinforcement_increment;
+extern float base_shield_strength;
+
+extern bool globalBaseVulnerabilityStatus;
+
+bool checkBaseVulnerabilityStatus();
 
 /// Holiday mode
 extern bool set_holiday_mode;

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -637,7 +637,7 @@ extern float shield_reinforcement_threshold_percent;
 extern float shield_reinforcement_increment;
 extern float base_shield_strength;
 
-extern bool globalBaseVulnerabilityStatus;
+extern bool isGlobalBaseInvulnerabilityActive;
 
 bool checkBaseVulnerabilityStatus();
 

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -153,7 +153,6 @@ public:
 	float SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints);
 	bool SpaceObjDestroyed(uint space_obj);
 	void SetReputation(int player_rep, float attitude);
-	void AddDmgTakenToThresholdCounterAndReinforceShield(float dmgTaken);
 	float FindWearNTearModifier(float currHpPercentage);
 
 	void RepairDamage(float max_base_health);

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -771,9 +771,8 @@ float PlayerBase::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 
 // Reset shield to default strength
 void PlayerBase::ResetShieldStrength() {
-	CoreModule *mod;
 	for (vector<Module*>::iterator i = modules.begin(); i != modules.end(); ++i) {
-		mod = dynamic_cast<CoreModule*>(*i);
+		CoreModule* mod = dynamic_cast<CoreModule*>(*i);
 		if (mod) {
 			mod->shield_strength_multiplier = base_shield_strength;
 			mod->damage_taken_since_last_threshold = 0;

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -768,3 +768,16 @@ float PlayerBase::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 
 	return 0.0f;
 }
+
+// Reset shield to default strength
+void PlayerBase::ResetShieldStrength() {
+	CoreModule *mod;
+	for (vector<Module*>::iterator i = modules.begin(); i != modules.end(); ++i) {
+		mod = dynamic_cast<CoreModule*>(*i);
+		if (mod) {
+			mod->shield_strength_multiplier = base_shield_strength;
+			mod->damage_taken_since_last_threshold = 0;
+			return;
+		}
+	}
+}


### PR DESCRIPTION
Reworked the shield system to the following:

Base.cfg specifies 'vulnerability windows', time periods where bases are vulnerable. Outside of those windows, bases are straight up impervious to damage other than wear&tear. 

Shield damage reduction starts relatively low, and ramps up the reduction as station takes damage, possibly going up to 100%, rendering the station invincible before the vulnerability period ends.

The damage reduction goes back to the specified default upon entering a vulnerability window.

Config file changes:
Base.cfg:
set_shield_damage_multiplier - deprecated
base_shield_strength - float, stores the baseline damage reduction for any shielded POB. shield_reinforcement_threshold - float, damage that needs to be taken by the station to increase the damage reduction. shield_reinforcement_increment - float, amount by which shield reduction increases after passing each threshold.
base_vulnerability_window - [integer, integer], multiple entries allowed - a pair of integers specifying a time window where bases are vulnerable (in local timezone). For example: values of 12, 15 would mean the POBs are vulnerable from noon until 3PM

Example scenario:
Base has 1000 HP, baseline shield is 50%, reinforcement threshold is 100HP, and increment is 10%. Let's assume there are no repairs in the game. Until the base loses 100HP, it will take 50% reduced damage, then, until it loses another 100HP(down to 800) it will have a 60% reduction. Eventually, at 500HP the base will become invulnerable until the next vulnerability window begins. nullptr fix