### PR TITLE
Added progressive Wear and Tear

### DIFF
--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -456,37 +456,33 @@ void CoreModule::RepairDamage(float max_base_health)
 
 bool CoreModule::Timer(uint time)
 {
-	if (space_obj && set_holiday_mode)
-	{
-		//force the base to keep max health
-		base->base_health = base->max_base_health;
-		float rhealth = base->base_health / base->max_base_health;
-		pub::SpaceObj::SetRelativeHealth(space_obj, rhealth);
-		//ConPrint(L"CoreModule::timer space_obj=%u health=%f maxhealth=%f\n", space_obj, base->base_health, base->max_base_health);
+
+	if ((time%set_tick_time) != 0 || set_holiday_mode) {
 		return false;
 	}
-
-	if ((time%set_tick_time) != 0)
-		return false;
 
 	if (space_obj)
 	{
 		if ((base->logic == 1) || (base->invulnerable == 0))
 		{
 
+			uint number_of_crew = base->HasMarketItem(set_base_crew_type);
+			bool isCrewSufficient = number_of_crew >= (base->base_level * 200);
 			pub::SpaceObj::GetHealth(space_obj, base->base_health, base->max_base_health);
 
 			if (!dont_rust && ((time%set_damage_tick_time) == 0))
 			{
+				float no_crew_penalty = isCrewSufficient ? 1.0f : no_crew_damage_multiplier;
+				float wear_n_tear_modifier = FindWearNTearModifier(base->base_health / base->max_base_health);
 				// Reduce hitpoints to reflect wear and tear. This will eventually
 				// destroy the base unless it is able to repair itself.
-				base->base_health -= set_damage_per_tick + (set_damage_per_tick * base->base_level);
+				float damage_taken = (set_damage_per_tick + (set_damage_per_tick * base->base_level)) * wear_n_tear_modifier * no_crew_penalty;
+				base->base_health -= damage_taken;
 			}
 
 			// Repair damage if we have sufficient crew on the base.
 			base->repairing = false;
-			uint number_of_crew = base->HasMarketItem(set_base_crew_type);
-			if (number_of_crew >= (base->base_level * 200)) {
+			if (isCrewSufficient) {
 				RepairDamage(base->max_base_health);
 				if (dont_eat) {
 					// We won't save base health below, so do it here
@@ -670,4 +666,13 @@ void CoreModule::SetReputation(int player_rep, float attitude)
 				player_rep, obj_rep, attitude, base->base);
 		pub::Reputation::SetAttitude(obj_rep, player_rep, attitude);
 	}
+}
+
+float CoreModule::FindWearNTearModifier(float currHpPercentage) {
+	for (list<WEAR_N_TEAR_MODIFIER>::iterator i = wear_n_tear_mod_list.begin(); i != wear_n_tear_mod_list.end(); ++i) {
+		if (i->fromHP < currHpPercentage && i->toHP >= currHpPercentage) {
+			return i->modifier;
+		}
+	}
+	return 1.0;
 }

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -75,6 +75,7 @@ string set_status_path_json;
 uint set_damage_per_tick = 600;
 
 /// Damage multiplier for damaged/abandoned stations
+/// In case of overlapping modifiers, only the first one specified in .cfg file will apply
 list<WEAR_N_TEAR_MODIFIER> wear_n_tear_mod_list;
 
 /// Additional damage penalty for stations without proper crew

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -74,6 +74,12 @@ string set_status_path_json;
 /// Damage to the base every tick
 uint set_damage_per_tick = 600;
 
+/// Damage multiplier for damaged/abandoned stations
+list<WEAR_N_TEAR_MODIFIER> wear_n_tear_mod_list;
+
+/// Additional damage penalty for stations without proper crew
+float no_crew_damage_multiplier = 1;
+
 // The seconds per damage tick
 uint set_damage_tick_time = 16;
 
@@ -435,6 +441,18 @@ void LoadSettingsActual()
 					else if (ini.is_value("damage_per_tick"))
 					{
 						set_damage_per_tick = ini.get_value_int(0);
+					}
+					else if (ini.is_value("damage_multiplier"))
+					{
+						WEAR_N_TEAR_MODIFIER mod;
+						mod.fromHP = ini.get_value_float(0);
+						mod.toHP = ini.get_value_float(1);
+						mod.modifier = ini.get_value_float(2);
+						wear_n_tear_mod_list.push_back(mod);
+					}
+					else if (ini.is_value("no_crew_damage_multiplier"))
+					{
+						no_crew_damage_multiplier = ini.get_value_float(0);
 					}
 					else if (ini.is_value("damage_tick_time"))
 					{

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -602,7 +602,8 @@ extern uint set_damage_per_10sec;
 /// Damage to the base every tick
 extern uint set_damage_per_tick;
 
-/// List of modifiers for progressive wear and tear damage scaling
+/// Damage multiplier for damaged/abandoned stations
+/// In case of overlapping modifiers, only the first one specified in .cfg file will apply
 extern list<WEAR_N_TEAR_MODIFIER> wear_n_tear_mod_list;
 
 /// Additional damage penalty for stations without proper crew

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -31,6 +31,12 @@ struct RECIPE
 	uint reqlevel;
 };
 
+struct WEAR_N_TEAR_MODIFIER{
+	float fromHP;
+	float toHP;
+	float modifier;
+};
+
 struct ARCHTYPE_STRUCT
 {
 	int logic;
@@ -138,6 +144,7 @@ public:
 	float SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints);
 	bool SpaceObjDestroyed(uint space_obj);
 	void SetReputation(int player_rep, float attitude);
+	float FindWearNTearModifier(float currHpPercentage);
 
 	void RepairDamage(float max_base_health);
 };
@@ -594,6 +601,12 @@ extern uint set_damage_per_10sec;
 
 /// Damage to the base every tick
 extern uint set_damage_per_tick;
+
+/// List of modifiers for progressive wear and tear damage scaling
+extern list<WEAR_N_TEAR_MODIFIER> wear_n_tear_mod_list;
+
+/// Additional damage penalty for stations without proper crew
+extern float no_crew_damage_multiplier;
 
 /// How much damage to repair per cycle
 extern uint repair_per_repair_cycle;


### PR DESCRIPTION
New config file properties:
Base.cfg:

damage_multiplier - float, float, float - FromHP, ToHP, Modifier - if base hp is between FromHP and ToHP (percent values from 0.0 to 1.0), multiply the wear and tear damage applied by Modifier value. Multiple entries allowed for different ranges, but only the first modifier matching a particular hitpoint percentage is ever applied. Logic defaults Modifier to 1 if no entry found.

no_crew_damage_multiplier - float - If station has insufficient crew to maintain the POB(Core level x200), the base, multiply the wear and tear by this value.