### PR TITLE
Pob QoL changes

### DIFF
--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1120,6 +1120,12 @@ bool UserCmd_Process(uint client, const wstring &args)
 		PlayerCommands::BaseInfo(client, args);
 		return true;
 	}
+	else if (args.find(L"/base check") == 0)
+	{
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+		PlayerCommands::GetNecessitiesStatus(client, args);
+		return true;
+	}
 	else if (args.find(L"/base facmod") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1120,7 +1120,7 @@ bool UserCmd_Process(uint client, const wstring &args)
 		PlayerCommands::BaseInfo(client, args);
 		return true;
 	}
-	else if (args.find(L"/base check") == 0)
+	else if (args.find(L"/base supplies") == 0)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		PlayerCommands::GetNecessitiesStatus(client, args);

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -528,6 +528,7 @@ namespace PlayerCommands
 	void BaseShieldMod(uint client, const wstring &args);
 	void Bank(uint client, const wstring &args);
 	void Shop(uint client, const wstring &args);
+	void GetNecessitiesStatus(uint client, const wstring &args);
 
 	void BaseDeploy(uint client, const wstring &args);
 

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -1825,6 +1825,52 @@ namespace PlayerCommands
 		}
 	}
 
+	void GetNecessitiesStatus(uint client, const wstring &args) {
+		// Check that this player is in a player controlled base
+		PlayerBase *base = GetPlayerBaseForClient(client);
+		if (!base)
+		{
+			PrintUserCmdText(client, L"ERR Not in player base");
+			return;
+		}
+
+		if (!clients[client].admin && !clients[client].viewshop)
+		{
+			PrintUserCmdText(client, L"ERROR: Access denied");
+			return;
+		}
+
+		if (base->HasMarketItem(set_base_crew_type) < base->base_level * 200) {
+			PrintUserCmdText(client, L"WARNING, CREW COUNT TOO LOW");
+		}
+		PrintUserCmdText(client, L"Crew: %u onboard", base->HasMarketItem(set_base_crew_type));
+
+		PrintUserCmdText(client, L"Crew supplies:");
+		for (map<uint, uint>::iterator i = set_base_crew_consumption_items.begin(); i != set_base_crew_consumption_items.end(); ++i) {
+			const GoodInfo *gi = GoodList::find_by_id(i->first);
+			if (gi)
+			{
+				PrintUserCmdText(client, L"    |%s: %u", HkGetWStringFromIDS(gi->iIDSName).c_str(), base->HasMarketItem(i->first));
+			}
+		}
+		
+		uint foodCount = 0;
+		for (map<uint, uint>::iterator i = set_base_crew_food_items.begin(); i != set_base_crew_food_items.end(); ++i) {
+			foodCount += base->HasMarketItem(i->first);
+		}
+		PrintUserCmdText(client, L"    |Food: %u", foodCount);
+
+		PrintUserCmdText(client, L"Repair materials:");
+		for (list<REPAIR_ITEM>::iterator i = set_base_repair_items.begin(); i != set_base_repair_items.end(); ++i) {
+
+			const GoodInfo *gi = GoodList::find_by_id(i->good);
+			if (gi)
+			{
+				PrintUserCmdText(client, L"    |%s: %u", HkGetWStringFromIDS(gi->iIDSName).c_str(), base->HasMarketItem(i->good));
+			}
+		}
+	}
+
 	void BaseDeploy(uint client, const wstring &args)
 	{
 		if (set_holiday_mode)

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -52,6 +52,9 @@ namespace PlayerCommands
 
 			L"<TRA bold=\"true\"/><TEXT>/base rep [clear]</TEXT><TRA bold=\"false\"/><PARA/>"
 			L"<TEXT>Set or clear the faction that this base is affiliated with. When setting the affiliation, the affiliation will be that of the player executing the command.</TEXT>";
+			
+			L"<TRA bold=\"true\"/><TEXT>/base check</TEXT><TRA bold=\"false\"/><PARA/>"
+			L"<TEXT>Prints Crew, Food, Water, Oxygen and repair material counts.</TEXT>";
 
 		pages[1] = L"<TRA bold=\"true\"/><TEXT>/bank withdraw [credits], /bank deposit [credits], /bank status</TEXT><TRA bold=\"false\"/><PARA/>"
 			L"<TEXT>Withdraw, deposit or check the status of the credits held by the base's bank.</TEXT><PARA/><PARA/>"

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -1577,6 +1577,12 @@ namespace PlayerCommands
 	{
 		PlayerBase *base = GetPlayerBaseForClient(client);
 
+		if (!base)
+		{
+			PrintUserCmdText(client, L"ERR Not in player base");
+			return;
+		}
+
 		const wstring &cmd = GetParam(args, ' ', 1);
 		int money = ToInt(GetParam(args, ' ', 2));
 

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -51,9 +51,9 @@ namespace PlayerCommands
 			L"<TEXT>Set the master password for the base.</TEXT><PARA/><PARA/>"
 
 			L"<TRA bold=\"true\"/><TEXT>/base rep [clear]</TEXT><TRA bold=\"false\"/><PARA/>"
-			L"<TEXT>Set or clear the faction that this base is affiliated with. When setting the affiliation, the affiliation will be that of the player executing the command.</TEXT>";
+			L"<TEXT>Set or clear the faction that this base is affiliated with. When setting the affiliation, the affiliation will be that of the player executing the command.</TEXT><PARA/><PARA/>"
 			
-			L"<TRA bold=\"true\"/><TEXT>/base check</TEXT><TRA bold=\"false\"/><PARA/>"
+			L"<TRA bold=\"true\"/><TEXT>/base supplies</TEXT><TRA bold=\"false\"/><PARA/>"
 			L"<TEXT>Prints Crew, Food, Water, Oxygen and repair material counts.</TEXT>";
 
 		pages[1] = L"<TRA bold=\"true\"/><TEXT>/bank withdraw [credits], /bank deposit [credits], /bank status</TEXT><TRA bold=\"false\"/><PARA/>"


### PR DESCRIPTION
/bank command now only works on Player Bases (currently doing a /bank deposit simply removes your money with no way of getting it back)

new command:
/base check - prints out crew, FOW and repair counts in a neatly formatted way.