### PR TITLE
New functionality: POB restricted commodity list

### DIFF
--- a/Binaries/bin-conf/flhook_plugins/base_forbidden_cargo.cfg
+++ b/Binaries/bin-conf/flhook_plugins/base_forbidden_cargo.cfg
@@ -1,0 +1,5 @@
+[forbidden_commodities]
+
+commodity_name = commodity_one
+commodity_name = commodity_two
+commodity_name = commodity_three

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -675,15 +675,13 @@ void LoadSettingsActual()
 		{
 			if (ini.is_header("forbidden_commodities"))
 			{
-				uint cargoID;
 				while (ini.read_value())
 				{
 					if (ini.is_value("commodity_name"))
 					{
-						cargoID = CreateID(ini.get_value_string(0));
+						forbidden_player_base_commodity_set.insert(CreateID(ini.get_value_string(0)));
 					}
 				}
-				forbidden_player_base_commodity_set.insert(cargoID);
 			}
 		}
 		ini.close();


### PR DESCRIPTION
Requested by Haste

New functionality - forbidden commodity list on POBs. Blocks attempts to sell a given cargo on a POB regardless if it's already on the manifest, base administrator status and so on. Allows to purchase the commodity from the base if it had it onboard due to admin intervention or had it stashed before this change went live.

new .cfg file: base_forbidden_cargo.cfg
structure:
[forbidden_commodities]

commodity_name = commodity_passengers
commodity_name = commodity_cardamine