### PR TITLE
Ships which are 'dead' cannot dock.

### DIFF
--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -302,7 +302,7 @@ namespace HkIEngine
 		else
 		{
 			if (Players[iClientID].fRelativeHealth == 0.0f && (iCancel != -1)) {
-				PrintUserCmdText(iClientID, L"Hull integrity failing, you cannot dock.");
+				pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("dock_disallowed"));
 				returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 				return 0;
 			}

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -301,6 +301,11 @@ namespace HkIEngine
 		}
 		else
 		{
+			if (Players[iClientID].fRelativeHealth == 0.0f && (iCancel != -1)) {
+				PrintUserCmdText(iClientID, L"Hull integrity failing, you cannot dock.");
+				returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+				return 0;
+			}
 			uint iTypeID;
 			pub::SpaceObj::GetType(iDockTarget, iTypeID);
 			if (iTypeID == OBJ_DOCKING_RING || iTypeID == OBJ_STATION)


### PR DESCRIPTION
Useful when ships have 'death fuses', and you want to prevent a 'dead' ship from docking to safety.
iCancel check is to avoid sending duplicate messages on dock attempt cancel.