### PR TITLE
fix: BalanceMagic no longer stops other plugins

### DIFF
--- a/Plugins/Public/alley/PlayerRestrictions.cpp
+++ b/Plugins/Public/alley/PlayerRestrictions.cpp
@@ -985,7 +985,7 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	return false;
 }
 
-void __stdcall HkCb_AddDmgEntry_AFTER(DamageList *dmg, unsigned short p1, float damage, enum DamageEntry::SubObjFate fate)
+void __stdcall HkCb_AddDmgEntry_AFTER(DamageList *dmg, unsigned short p1, float& damage, enum DamageEntry::SubObjFate fate)
 {
 	returncode = DEFAULT_RETURNCODE;
 	if (iDmgToSpaceID && dmg->get_inflictor_id() && dmg->is_inflictor_a_player())

--- a/Plugins/Public/balancemagic/Main.cpp
+++ b/Plugins/Public/balancemagic/Main.cpp
@@ -198,7 +198,7 @@ bool UserCmd_Process(uint iClientID, const wstring &wscCmd)
 	return false;
 }
 
-void __stdcall HkCb_AddDmgEntry(DamageList *dmg, ushort subObjID, float setHealth, DamageEntry::SubObjFate fate)
+void __stdcall HkCb_AddDmgEntry(DamageList *dmg, ushort subObjID, float& setHealth, DamageEntry::SubObjFate fate)
 {
 	returncode = DEFAULT_RETURNCODE;
 	if (iDmgToSpaceID && iDmgMunitionID)
@@ -253,14 +253,6 @@ void __stdcall HkCb_AddDmgEntry(DamageList *dmg, ushort subObjID, float setHealt
 			// Fix wrong death message bug.
 			if (iDmgTo && subObjID == 1)
 				ClientInfo[iDmgTo].dmgLast = *dmg;
-
-			// Add damage entry instead of FLHook Core.
-			dmg->add_damage_entry(subObjID, setHealth, fate);
-			returncode = SKIPPLUGINS_NOFUNCTIONCALL;
-
-			iDmgTo = 0;
-			iDmgToSpaceID = 0;
-			iDmgMunitionID = 0;
 		}
 	}
 }

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1994,7 +1994,7 @@ void BaseDestroyed(uint space_obj, uint client)
 	}
 }
 
-void __stdcall HkCb_AddDmgEntry(DamageList *dmg, unsigned short p1, float damage, enum DamageEntry::SubObjFate fate)
+void __stdcall HkCb_AddDmgEntry(DamageList *dmg, unsigned short p1, float& damage, enum DamageEntry::SubObjFate fate)
 {
 	returncode = DEFAULT_RETURNCODE;
 	if (iDmgToSpaceID && dmg->get_inflictor_id())

--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -845,7 +845,7 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	return false;
 }
 
-void __stdcall HkCb_AddDmgEntry(DamageList *dmg, unsigned short p1, float damage, enum DamageEntry::SubObjFate fate)
+void __stdcall HkCb_AddDmgEntry(DamageList *dmg, unsigned short p1, float& damage, enum DamageEntry::SubObjFate fate)
 {
 	returncode = DEFAULT_RETURNCODE;
 	if (iDmgToSpaceID && dmg->get_inflictor_id())

--- a/Plugins/Public/pvecontroller/Main.cpp
+++ b/Plugins/Public/pvecontroller/Main.cpp
@@ -538,7 +538,7 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 //Functions to hook
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void __stdcall HkCb_AddDmgEntry(DamageList *dmg, unsigned short p1, float damage, enum DamageEntry::SubObjFate fate)
+void __stdcall HkCb_AddDmgEntry(DamageList *dmg, unsigned short p1, float& damage, enum DamageEntry::SubObjFate fate)
 {
 	returncode = DEFAULT_RETURNCODE;
 	uint iDmgFrom = HkGetClientIDByShip(dmg->get_inflictor_id());

--- a/Source/FLHook/HkCbDamage.cpp
+++ b/Source/FLHook/HkCbDamage.cpp
@@ -86,7 +86,7 @@ however you can't figure out here, which ship is being damaged, that's why i use
 void __stdcall HkCb_AddDmgEntry(DamageList *dmgList, unsigned short p1, float p2, enum DamageEntry::SubObjFate p3)
 {
 
-	CALL_PLUGINS_V(PLUGIN_HkCb_AddDmgEntry, __stdcall, (DamageList *, unsigned short, float, DamageEntry::SubObjFate), (dmgList, p1, p2, p3));
+	CALL_PLUGINS_V(PLUGIN_HkCb_AddDmgEntry, __stdcall, (DamageList *, unsigned short, float&, DamageEntry::SubObjFate), (dmgList, p1, p2, p3));
 
 	//check if we've got dmged by a cd with changed behaviour
 	if (dmgList->get_cause() == 0xC0)
@@ -146,7 +146,7 @@ void __stdcall HkCb_AddDmgEntry(DamageList *dmgList, unsigned short p1, float p2
 	}
 	catch (...) { LOG_EXCEPTION }
 
-	CALL_PLUGINS_V(PLUGIN_HkCb_AddDmgEntry_AFTER, __stdcall, (DamageList *, unsigned short, float, DamageEntry::SubObjFate), (dmgList, p1, p2, p3));
+	CALL_PLUGINS_V(PLUGIN_HkCb_AddDmgEntry_AFTER, __stdcall, (DamageList *, unsigned short, float&, DamageEntry::SubObjFate), (dmgList, p1, p2, p3));
 
 	iDmgTo = 0;
 	iDmgToSpaceID = 0;


### PR DESCRIPTION
Instead of sending our own damage entry (losing a lot of metadata such as attacker info) and stopping other plugins on the same hook from executing, we just override the new HP value that will then be 'naturally' passed on to be processed by the server and other plugins "As Chris Roberts intended"

Done by sending the 'newHealth' float as reference instead of as a copy, akin to FLHook4.