### PR TITLE
Jumpdrive charge disruption changes

### DIFF
--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -1690,6 +1690,7 @@ namespace HyperJump
 				if (dmg->get_cause() == 6)
 				{
 					mapJumpDrives[iClientID].charging_on = false;
+					mapJumpDrives[iClientID].curr_charge = 0;
 					PrintUserCmdText(iClientID, L"Jump drive disrupted. Charging failed.");
 					pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_jumpdrive_charging_failed"));
 					SetFuse(iClientID, 0);

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -1687,7 +1687,7 @@ namespace HyperJump
 		{
 			if (mapJumpDrives[iClientID].charging_on && mapJumpDrives[iClientID].arch.cd_disrupts_charge)
 			{
-				if (dmg->get_cause() == 6)
+				if (dmg->get_cause() == 6 || dmg->get_cause() == 0x15)
 				{
 					mapJumpDrives[iClientID].charging_on = false;
 					mapJumpDrives[iClientID].curr_charge = 0;


### PR DESCRIPTION
- CDing a charging jump drive will now reset the progress instead of merely pausing it
- 'alternate' CD damage type will also interrupt charging 