### PR TITLE
probable fix for "CD doesn't always interrupt cloak" bug

### DIFF
--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -850,7 +850,7 @@ void __stdcall HkCb_AddDmgEntry(DamageList *dmg, unsigned short p1, float& damag
 	returncode = DEFAULT_RETURNCODE;
 	if (iDmgToSpaceID && dmg->get_inflictor_id())
 	{
-		if (dmg->get_cause() == 0x06)
+		if (dmg->get_cause() == 0x06 || dmg->get_cause() == 0x15)
 		{
 			float curr, max;
 			pub::SpaceObj::GetHealth(iDmgToSpaceID, curr, max);


### PR DESCRIPTION
I couldn't personally reproduce, could be caused by FLHook/plugin config?
0x15 is another cruise disruptor damage type, and is used in other places (such as HyperJump plugin) for comparisons