### PR TITLE
New: Shipclass based purchase restrictions

### DIFF
--- a/Plugins/Public/alley/PlayerRestrictions.cpp
+++ b/Plugins/Public/alley/PlayerRestrictions.cpp
@@ -1202,7 +1202,7 @@ void __stdcall ReqAddItem(unsigned int iArchID, char const *Hardpoint, int count
 	*/
 
 	returncode = DEFAULT_RETURNCODE;
-	if (reverseTrade[iClientID] == true)
+	if (reverseTrade[iClientID])
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 	}
@@ -1211,7 +1211,7 @@ void __stdcall ReqAddItem(unsigned int iArchID, char const *Hardpoint, int count
 void __stdcall GFGoodBuy(struct SGFGoodBuyInfo const &gbi, unsigned int client)
 {
 	returncode = DEFAULT_RETURNCODE;
-	if (false == SCI::CanBuyItem(gbi.iGoodID, client)) {
+	if (!SCI::CanBuyItem(gbi.iGoodID, client)) {
 		const GoodInfo* gi = GoodList::find_by_id(gbi.iGoodID);
 		switch (gi->iType) {
 			case GOODINFO_TYPE_COMMODITY: {
@@ -1237,7 +1237,7 @@ void __stdcall GFGoodBuy(struct SGFGoodBuyInfo const &gbi, unsigned int client)
 void __stdcall ReqChangeCash(int cash, unsigned int iClientID)
 {
 	returncode = DEFAULT_RETURNCODE;
-	if (reverseTrade[iClientID] == true)
+	if (reverseTrade[iClientID])
 	{
 		reverseTrade[iClientID] = false;
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
@@ -1247,7 +1247,7 @@ void __stdcall ReqChangeCash(int cash, unsigned int iClientID)
 void __stdcall ReqSetCash(int cash, unsigned int iClientID)
 {
 	returncode = DEFAULT_RETURNCODE;
-	if (reverseTrade[iClientID] == true)
+	if (reverseTrade[iClientID])
 	{
 		reverseTrade[iClientID] = false;
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;

--- a/Plugins/Public/alley/PlayerRestrictions.cpp
+++ b/Plugins/Public/alley/PlayerRestrictions.cpp
@@ -167,6 +167,7 @@ static map<uint, string> notradelist;
 static list<uint> MarkedPlayers;
 //Added this due to idiocy
 static list<uint> MarkUsageTimer;
+static map<uint, bool> reverseTrade;
 
 
 
@@ -1199,7 +1200,60 @@ void __stdcall ReqAddItem(unsigned int iArchID, char const *Hardpoint, int count
 		PrintUserCmdText(iClientID, L"Triggered on add equip");
 	}
 	*/
+
+	returncode = DEFAULT_RETURNCODE;
+	if (reverseTrade[iClientID] == true)
+	{
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+	}
 }
+
+void __stdcall GFGoodBuy(struct SGFGoodBuyInfo const &gbi, unsigned int client)
+{
+	returncode = DEFAULT_RETURNCODE;
+	if (false == SCI::CanBuyItem(gbi.iGoodID, client)) {
+		const GoodInfo* gi = GoodList::find_by_id(gbi.iGoodID);
+		switch (gi->iType) {
+			case GOODINFO_TYPE_COMMODITY: {
+				PrintUserCmdText(client, L"ERR Your ship can't load this cargo");
+				break;
+			}
+			case GOODINFO_TYPE_EQUIPMENT: {
+				PrintUserCmdText(client, L"ERR Your ship can't use this equipment");
+				break;
+			}
+			default:
+				PrintUserCmdText(client, L"ERR You can't buy this");
+		}
+
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+		reverseTrade[client] = true;
+		return;
+	}
+
+	reverseTrade[client] = false;
+}
+
+void __stdcall ReqChangeCash(int cash, unsigned int iClientID)
+{
+	returncode = DEFAULT_RETURNCODE;
+	if (reverseTrade[iClientID] == true)
+	{
+		reverseTrade[iClientID] = false;
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+	}
+}
+
+void __stdcall ReqSetCash(int cash, unsigned int iClientID)
+{
+	returncode = DEFAULT_RETURNCODE;
+	if (reverseTrade[iClientID] == true)
+	{
+		reverseTrade[iClientID] = false;
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+	}
+}
+
 
 void __stdcall ReqEquipment(class EquipDescList const &edl, unsigned int iClientID)
 {
@@ -1284,6 +1338,9 @@ EXPORT PLUGIN_INFO* Get_PluginInfo()
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkCb_AddDmgEntry_AFTER, PLUGIN_HkCb_AddDmgEntry_AFTER, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&JettisonCargo, PLUGIN_HkIServerImpl_JettisonCargo, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&AddTradeEquip, PLUGIN_HkIServerImpl_AddTradeEquip, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&GFGoodBuy, PLUGIN_HkIServerImpl_GFGoodBuy, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&ReqChangeCash, PLUGIN_HkIServerImpl_ReqChangeCash, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&ReqSetCash, PLUGIN_HkIServerImpl_ReqSetCash, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&BaseEnter_AFTER, PLUGIN_HkIServerImpl_BaseEnter_AFTER, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&ClearClientInfo, PLUGIN_ClearClientInfo, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&SystemSwitchOutComplete, PLUGIN_HkIServerImpl_SystemSwitchOutComplete, 0));

--- a/Plugins/Public/alley/PlayerRestrictions.h
+++ b/Plugins/Public/alley/PlayerRestrictions.h
@@ -25,6 +25,7 @@ namespace SCI
 {
 	void LoadSettings();
 	void CheckItems(unsigned int iClientID);
+	bool CanBuyItem(uint iArchID, uint iClientID);
 	void ClearClientInfo(unsigned int iClientID);
 	void CheckOwned(unsigned int iClientID);
 	void UpdatePlayerID(unsigned int iClientID);

--- a/Plugins/Public/alley/shipclass_item.cpp
+++ b/Plugins/Public/alley/shipclass_item.cpp
@@ -279,6 +279,21 @@ void SCI::CheckItems(unsigned int iClientID)
 	return;
 }
 
+bool SCI::CanBuyItem(uint iArchID, uint iClientID) {
+
+	auto foundItem = shipclassitems.find(iArchID);
+	if (foundItem != shipclassitems.end()) {
+		Archetype::Ship* shipArch = Archetype::GetShip(Players[iClientID].iShipArchetype);
+		for (uint allowedClass : foundItem->second.canmount) {
+			if (allowedClass == shipArch->iShipClass) {
+				return true;
+			}
+		}
+		return false;
+	}
+	return true;
+}
+
 // based on conn plugin
 void SCI::StoreReturnPointForClient(unsigned int client)
 {


### PR DESCRIPTION
- added a basic check for shipclass immediately on item purchase
- said check extends to commodities as well as equipment
- old logic of checking full configuration on base launch remains unchanged