### PR TITLE
Siege rework enhancement

### DIFF
--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -576,15 +576,6 @@ float CoreModule::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 {
 	base->SpaceObjDamaged(space_obj, attacking_space_obj, curr_hitpoints, new_hitpoints);
 
-	if (set_holiday_mode || (base->basetype == "jumpgate") || (base->basetype == "jumphole") || (base->basetype == "airlock") || (base->basetype == "planet"))
-	{
-		//force the base to keep max health
-		base->base_health = base->max_base_health;
-		float rhealth = base->base_health / base->max_base_health;
-		pub::SpaceObj::SetRelativeHealth(space_obj, rhealth);
-		return curr_hitpoints;
-	}
-
 	if (base->shield_state != PlayerBase::SHIELD_STATE_OFFLINE && base->shield_strength_multiplier < 1.0 && !isGlobalBaseInvulnerabilityActive && base->invulnerable == 0)
 	{
 		float damageTaken = ((curr_hitpoints - new_hitpoints) * (1 - base->shield_strength_multiplier));

--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -13,7 +13,7 @@
 #include <hookext_exports.h>
 
 CoreModule::CoreModule(PlayerBase *the_base) : Module(TYPE_CORE), base(the_base), space_obj(0), dont_eat(false), 
-dont_rust(false), shield_strength_multiplier(base_shield_strength), damage_taken_since_last_threshold(0)
+dont_rust(false)
 {
 }
 
@@ -357,9 +357,9 @@ void CoreModule::Spawn()
 		pub::SpaceObj::SetRelativeHealth(space_obj, base->base_health / base->max_base_health);
 
 		if (shield_reinforcement_threshold_map.count(base->base_level))
-			base_shield_reinforcement_threshold = shield_reinforcement_threshold_map[base->base_level];
+			base->base_shield_reinforcement_threshold = shield_reinforcement_threshold_map[base->base_level];
 		else
-			base_shield_reinforcement_threshold = 0.0f;
+			base->base_shield_reinforcement_threshold = 0.0f;
 
 		base->SyncReputationForBaseObject(space_obj);
 		if (set_plugin_debug > 1)
@@ -585,14 +585,14 @@ float CoreModule::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 		return curr_hitpoints;
 	}
 
-	if (base->shield_state != PlayerBase::SHIELD_STATE_OFFLINE && shield_strength_multiplier < 1.0 && !isGlobalBaseInvulnerabilityActive && base->invulnerable == 0)
+	if (base->shield_state != PlayerBase::SHIELD_STATE_OFFLINE && base->shield_strength_multiplier < 1.0 && !isGlobalBaseInvulnerabilityActive && base->invulnerable == 0)
 	{
-		float damageTaken = ((curr_hitpoints - new_hitpoints) * (1 - shield_strength_multiplier));
+		float damageTaken = ((curr_hitpoints - new_hitpoints) * (1 - base->shield_strength_multiplier));
 
-		damage_taken_since_last_threshold += damageTaken;
-		if (damage_taken_since_last_threshold >= base_shield_reinforcement_threshold) {
-			damage_taken_since_last_threshold -= base_shield_reinforcement_threshold;
-			shield_strength_multiplier += shield_reinforcement_increment;
+		base->damage_taken_since_last_threshold += damageTaken;
+		if (base->damage_taken_since_last_threshold >= base->base_shield_reinforcement_threshold) {
+			base->damage_taken_since_last_threshold -= base->base_shield_reinforcement_threshold;
+			base->shield_strength_multiplier += shield_reinforcement_increment;
 		}
 
 		return curr_hitpoints - damageTaken;

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -2828,7 +2828,8 @@ EXPORT PLUGIN_INFO* Get_PluginInfo()
 
 void ResetAllBasesShieldStrength() {
 	for (map<uint, PlayerBase*>::iterator i = player_bases.begin(); i != player_bases.end(); ++i) {
-		i->second->ResetShieldStrength();
+		i->second->shield_strength_multiplier = base_shield_strength;
+		i->second->damage_taken_since_last_threshold = 0;
 	}
 }
 

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -131,10 +131,6 @@ public:
 	// If true, do not take damage
 	bool dont_rust;
 
-	float shield_strength_multiplier;
-	float base_shield_reinforcement_threshold;
-	float damage_taken_since_last_threshold;
-
 	// The list of goods and usage of goods per minute for the autosys effect
 	map<uint, uint> mapAutosysGood;
 
@@ -312,7 +308,6 @@ public:
 	void SyncReputationForBaseObject(uint space_obj);
 
 	float SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints);
-	void ResetShieldStrength();
 
 	// The base nickname
 	string nickname;
@@ -382,6 +377,11 @@ public:
 
 	//changes how defense mod act depending on the amount of damage made to base in the last hours
 	bool siege_mode;
+
+	//shield strength parameters
+	float shield_strength_multiplier;
+	float base_shield_reinforcement_threshold;
+	float damage_taken_since_last_threshold;
 
 	// List of allied ship tags.
 	list<wstring> ally_tags;

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -4,7 +4,8 @@ PlayerBase::PlayerBase(uint client, const wstring &password, const wstring &the_
 	: basename(the_basename),
 	base(0), money(0), base_health(0),
 	base_level(1), defense_mode(0), proxy_base(0), affiliation(0), siege_mode(false),
-	repairing(false), shield_active_time(0), shield_state(PlayerBase::SHIELD_STATE_OFFLINE)
+	repairing(false), shield_active_time(0), shield_state(PlayerBase::SHIELD_STATE_OFFLINE),
+	shield_strength_multiplier(base_shield_strength), damage_taken_since_last_threshold(0)
 {
 	nickname = CreateBaseNickname(wstos(basename));
 	base = CreateID(nickname.c_str());
@@ -37,8 +38,9 @@ PlayerBase::PlayerBase(uint client, const wstring &password, const wstring &the_
 
 PlayerBase::PlayerBase(const string &the_path)
 	: path(the_path), base(0), money(0),
-	base_health(0), base_level(0), defense_mode(0), proxy_base(0), affiliation(0),
-	repairing(false), shield_active_time(0), shield_state(PlayerBase::SHIELD_STATE_OFFLINE)
+	base_health(0), base_level(0), defense_mode(0), proxy_base(0), affiliation(0), siege_mode(false),
+	repairing(false), shield_active_time(0), shield_state(PlayerBase::SHIELD_STATE_OFFLINE),
+	shield_strength_multiplier(base_shield_strength), damage_taken_since_last_threshold(0)
 {
 	// Load and spawn base modules
 	Load();
@@ -223,6 +225,14 @@ void PlayerBase::Load()
 					{
 						invulnerable = ini.get_value_int(0);
 					}
+					else if (ini.is_value("shieldstrength"))
+					{
+						shield_strength_multiplier = ini.get_value_float(0);
+					}
+					else if (ini.is_value("shielddmgtaken"))
+					{
+						damage_taken_since_last_threshold = ini.get_value_float(0);
+					}
 					else if (ini.is_value("destposition"))
 					{
 						destposition.x = ini.get_value_float(0);
@@ -376,6 +386,8 @@ void PlayerBase::Save()
 		fprintf(file, "affiliation = %u\n", affiliation);
 		fprintf(file, "logic = %u\n", logic);
 		fprintf(file, "invulnerable = %u\n", invulnerable);
+		fprintf(file, "shieldstrength = %f", shield_strength_multiplier);
+		fprintf(file, "shielddmgtaken = %f", damage_taken_since_last_threshold);
 
 		fprintf(file, "money = %I64d\n", money);
 		fprintf(file, "system = %u\n", system);
@@ -767,16 +779,4 @@ float PlayerBase::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 	}
 
 	return 0.0f;
-}
-
-// Reset shield to default strength
-void PlayerBase::ResetShieldStrength() {
-	for (vector<Module*>::iterator i = modules.begin(); i != modules.end(); ++i) {
-		CoreModule* mod = dynamic_cast<CoreModule*>(*i);
-		if (mod) {
-			mod->shield_strength_multiplier = base_shield_strength;
-			mod->damage_taken_since_last_threshold = 0;
-			return;
-		}
-	}
 }

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -386,8 +386,8 @@ void PlayerBase::Save()
 		fprintf(file, "affiliation = %u\n", affiliation);
 		fprintf(file, "logic = %u\n", logic);
 		fprintf(file, "invulnerable = %u\n", invulnerable);
-		fprintf(file, "shieldstrength = %f", shield_strength_multiplier);
-		fprintf(file, "shielddmgtaken = %f", damage_taken_since_last_threshold);
+		fprintf(file, "shieldstrength = %f\n", shield_strength_multiplier);
+		fprintf(file, "shielddmgtaken = %f\n", damage_taken_since_last_threshold);
 
 		fprintf(file, "money = %I64d\n", money);
 		fprintf(file, "system = %u\n", system);

--- a/Plugins/Public/base_plugin/ShieldModule.cpp
+++ b/Plugins/Public/base_plugin/ShieldModule.cpp
@@ -6,6 +6,7 @@ ShieldModule::ShieldModule(PlayerBase *the_base)
 	: Module(TYPE_SHIELDGEN), base(the_base), reset_needed(false)
 {
 	shield_fuse = CreateID("player_base_shield");
+	base->shield_state = HasShieldPower() ? PlayerBase::SHIELD_STATE_ONLINE : PlayerBase::SHIELD_STATE_OFFLINE;
 }
 
 ShieldModule::~ShieldModule()


### PR DESCRIPTION
- moved shield variables from CoreModule to PlayerBase
- saving relevant variables to playerbase ini file (maintain the shield parameters in case of mid-siege crash)
- removed "holiday mode fixes all POBs" code block (again)
- set the shield to online immediately on server startup, preventing a free shot before the Timer() executes for the first time