### PR TITLE
POB save cycle rework

### DIFF
--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -463,10 +463,6 @@ void CoreModule::RepairDamage(float max_base_health)
 bool CoreModule::Timer(uint time)
 {
 
-	if ((time%set_tick_time) != 0 || set_holiday_mode) {
-		return false;
-	}
-
 	if (space_obj)
 	{
 		if ((base->logic == 1) || (base->invulnerable == 0))
@@ -499,7 +495,7 @@ bool CoreModule::Timer(uint time)
 
 			if (base->base_health > base->max_base_health)
 				base->base_health = base->max_base_health;
-			else if (base->base_health <= 0)
+			else if (base->base_health < 0)
 				base->base_health = 0;
 
 			if (!dont_eat)

--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -463,6 +463,10 @@ void CoreModule::RepairDamage(float max_base_health)
 bool CoreModule::Timer(uint time)
 {
 
+	if ((time%set_tick_time) != 0 || set_holiday_mode) {
+		return false;
+	}
+
 	if (space_obj)
 	{
 		if ((base->logic == 1) || (base->invulnerable == 0))
@@ -495,7 +499,7 @@ bool CoreModule::Timer(uint time)
 
 			if (base->base_health > base->max_base_health)
 				base->base_health = base->max_base_health;
-			else if (base->base_health < 0)
+			else if (base->base_health <= 0)
 				base->base_health = 0;
 
 			if (!dont_eat)

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -28,6 +28,7 @@ map<uint, CLIENT_DATA> clients;
 
 // Bases
 map<uint, PlayerBase*> player_bases;
+map<uint, PlayerBase*>::iterator repairIterator = player_bases.begin();
 
 map<uint, bool> mapPOBShipPurchases;
 
@@ -828,6 +829,21 @@ void HkTimerCheckKick()
 		++iter;
 		// Dispatch timer but we can safely ignore the return
 		base->Timer(curr_time);
+	}
+	if (!player_bases.empty() && !set_holiday_mode) {
+		if (repairIterator == player_bases.end()) {
+			repairIterator = player_bases.begin();
+		}
+		bool repairSuccessful = false;
+		while (!repairSuccessful || repairIterator == player_bases.end()) {
+			auto& pb = repairIterator->second;
+			ConPrint(L"Attempting to Fixing base %ls\n", pb->basename.c_str());
+			if (pb->logic == 1 || pb->invulnerable == 0) {
+				pb->Save();
+				repairSuccessful = true;
+			}
+			repairIterator++;
+		}
 	}
 
 	if (ExportType == 0 || ExportType == 2)

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -28,7 +28,7 @@ map<uint, CLIENT_DATA> clients;
 
 // Bases
 map<uint, PlayerBase*> player_bases;
-map<uint, PlayerBase*>::iterator repairIterator = player_bases.begin();
+map<uint, PlayerBase*>::iterator baseSaveIterator = player_bases.begin();
 
 map<uint, bool> mapPOBShipPurchases;
 
@@ -831,17 +831,17 @@ void HkTimerCheckKick()
 		base->Timer(curr_time);
 	}
 	if (!player_bases.empty() && !set_holiday_mode) {
-		if (repairIterator == player_bases.end()) {
-			repairIterator = player_bases.begin();
+		if (baseSaveIterator == player_bases.end()) {
+			baseSaveIterator = player_bases.begin();
 		}
-		bool repairSuccessful = false;
-		while (!repairSuccessful && repairIterator != player_bases.end()) {
-			auto& pb = repairIterator->second;
+		bool saveSuccessful = false;
+		while (!saveSuccessful && baseSaveIterator != player_bases.end()) {
+			auto& pb = baseSaveIterator->second;
 			if (pb->logic == 1 || pb->invulnerable == 0) {
 				pb->Save();
-				repairSuccessful = true;
+				saveSuccessful = true;
 			}
-			repairIterator++;
+			baseSaveIterator++;
 		}
 	}
 

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -835,9 +835,8 @@ void HkTimerCheckKick()
 			repairIterator = player_bases.begin();
 		}
 		bool repairSuccessful = false;
-		while (!repairSuccessful || repairIterator == player_bases.end()) {
+		while (!repairSuccessful && repairIterator != player_bases.end()) {
 			auto& pb = repairIterator->second;
-			ConPrint(L"Attempting to Fixing base %ls\n", pb->basename.c_str());
 			if (pb->logic == 1 || pb->invulnerable == 0) {
 				pb->Save();
 				repairSuccessful = true;

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -563,7 +563,7 @@ extern map<uint, Module*> spaceobj_modules;
 
 // Map of ingame hash to info
 extern map<uint, class PlayerBase*> player_bases;
-extern map<uint, PlayerBase*>::iterator repairIterator;
+extern map<uint, PlayerBase*>::iterator baseSaveIterator;
 
 struct POBSOUNDS
 {

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -563,6 +563,7 @@ extern map<uint, Module*> spaceobj_modules;
 
 // Map of ingame hash to info
 extern map<uint, class PlayerBase*> player_bases;
+extern map<uint, PlayerBase*>::iterator repairIterator;
 
 struct POBSOUNDS
 {

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -87,14 +87,6 @@ bool PlayerBase::Timer(uint curr_time)
 				return true;
 		}
 	}
-	/*
-	// Save base status every 60 seconds.
-	if (save_timer-- < 0)
-	{
-		save_timer = 60;
-		Save();
-	}
-	*/
 	return false;
 }
 

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -87,14 +87,14 @@ bool PlayerBase::Timer(uint curr_time)
 				return true;
 		}
 	}
-
+	/*
 	// Save base status every 60 seconds.
 	if (save_timer-- < 0)
 	{
 		save_timer = 60;
 		Save();
 	}
-
+	*/
 	return false;
 }
 

--- a/Plugins/Public/base_plugin/SaveFiles.cpp
+++ b/Plugins/Public/base_plugin/SaveFiles.cpp
@@ -52,6 +52,7 @@ void DeleteBase(PlayerBase *base)
 	}
 
 	player_bases.erase(base->base);
+	repairIterator = player_bases.begin();
 	delete base;
 }
 

--- a/Plugins/Public/base_plugin/SaveFiles.cpp
+++ b/Plugins/Public/base_plugin/SaveFiles.cpp
@@ -52,7 +52,7 @@ void DeleteBase(PlayerBase *base)
 	}
 
 	player_bases.erase(base->base);
-	repairIterator = player_bases.begin();
+	baseSaveIterator = player_bases.begin();
 	delete base;
 }
 


### PR DESCRIPTION
Instead of saving all POBs once a minute, this change changes it to instead behave as a rolling update, where every second, one POB is saved until the iterator reaches the end of the list, then starts from the beginning, resulting in avoiding the massive load spike from opening and saving into ~200 files at once.