### PR TITLE
Cloak momentum based consumption

### DIFF
--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -74,6 +74,7 @@ struct CLOAK_INFO
 
 	ushort iCloakSlot;
 	bool bCanCloak;
+	bool bInWarpGate;
 	mstime tmCloakTime;
 	uint iState;
 	bool bAdmin;
@@ -311,6 +312,9 @@ void SetState(uint iClientID, uint iShipID, int iNewState)
 static bool ProcessFuel(uint iClientID, CLOAK_INFO &info, uint iShipID)
 {
 	if (info.bAdmin)
+		return true;
+
+	if(setJumpingClients.find(iClientID) != setJumpingClients.end())
 		return true;
 
 	for (list<EquipDesc>::iterator item = Players[iClientID].equipDescList.equip.begin(); item != Players[iClientID].equipDescList.equip.end(); item++)

--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -546,7 +546,7 @@ void HkTimerCheckKick()
 									}
 									else
 									{
-										PrintUserCmdText(iClientID, L"Cloak broken by %ls", (const wchar_t*)Players.GetActiveCharacterName(pPD->iOnlineID));
+										PrintUserCmdText(iClientID, L"Cloak broken by proximity to another vessel!");
 										SetState(iClientID, iShipID, STATE_CLOAK_OFF);
 										break;
 									}

--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -180,7 +180,7 @@ void LoadSettings()
 						device.bBreakOnProximity = ini.get_value_bool(0);
 					}
 					else if (ini.is_value("detection_range")) {
-						device.fRange = ini.get_value_float(0);;
+						device.fRange = ini.get_value_float(0);
 					}
 				}
 				mapCloakingDevices[CreateID(device.scNickName.c_str())] = device;

--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -74,7 +74,6 @@ struct CLOAK_INFO
 
 	ushort iCloakSlot;
 	bool bCanCloak;
-	bool bInWarpGate;
 	mstime tmCloakTime;
 	uint iState;
 	bool bAdmin;

--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -296,7 +296,7 @@ static bool ProcessFuel(uint iClientID, CLOAK_INFO &info, uint iShipID)
 
 	for (list<EquipDesc>::iterator item = Players[iClientID].equipDescList.equip.begin(); item != Players[iClientID].equipDescList.equip.end(); item++)
 	{
-		if (item->sID == info.iCloakSlot)
+		if (info.arch.mapFuelToUsage.find(item->iArchID) != info.arch.mapFuelToUsage.end())
 		{
 			const auto& fuelUsage = info.arch.mapFuelToUsage[item->iArchID];
 			uint currFuelUsage = fuelUsage.usageStatic;
@@ -313,7 +313,8 @@ static bool ProcessFuel(uint iClientID, CLOAK_INFO &info, uint iShipID)
 				pub::Player::RemoveCargo(iClientID, item->sID, currFuelUsage);
 				return true;
 			}
-			break;
+			if(info.arch.mapFuelToUsage.size() == 1)
+				break;
 		}
 	}
 	return false;

--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -56,11 +56,11 @@ struct CLOAK_INFO
 	CLOAK_INFO()
 	{
 
-		uint iCloakSlot = 0;
+		iCloakSlot = 0;
 		bCanCloak = false;
-		mstime tmCloakTime = 0;
-		uint iState = STATE_CLOAK_INVALID;
-		uint bAdmin = false;
+		tmCloakTime = 0;
+		iState = STATE_CLOAK_INVALID;
+		bAdmin = false;
 
 		arch.iWarmupTime = 0;
 		arch.iCooldownTime = 0;
@@ -69,13 +69,12 @@ struct CLOAK_INFO
 		arch.bDropShieldsOnUncloak = false;
 	}
 
-	uint iCloakSlot;
+	ushort iCloakSlot;
 	bool bCanCloak;
 	mstime tmCloakTime;
 	uint iState;
 	bool bAdmin;
 	int DisruptTime;
-	bool singleCloakConsumed = false;
 
 	CLOAK_ARCH arch;
 };
@@ -297,7 +296,7 @@ static bool ProcessFuel(uint iClientID, CLOAK_INFO &info, uint iShipID)
 
 	for (list<EquipDesc>::iterator item = Players[iClientID].equipDescList.equip.begin(); item != Players[iClientID].equipDescList.equip.end(); item++)
 	{
-		if (info.arch.mapFuelToUsage.find(item->iArchID) != info.arch.mapFuelToUsage.end())
+		if (item->sID == info.iCloakSlot)
 		{
 			const auto& fuelUsage = info.arch.mapFuelToUsage[item->iArchID];
 			uint currFuelUsage = fuelUsage.usageStatic;
@@ -305,18 +304,18 @@ static bool ProcessFuel(uint iClientID, CLOAK_INFO &info, uint iShipID)
 				Vector dir1;
 				Vector dir2;
 				pub::SpaceObj::GetMotion(iShipID, dir1, dir2);
-				uint vecLength = sqrtf(dir1.x * dir1.x + dir1.y * dir1.y + dir1.z * dir1.z);
+				float vecLength = sqrtf(dir1.x * dir1.x + dir1.y * dir1.y + dir1.z * dir1.z);
 				
-				currFuelUsage += fuelUsage.usageMove * vecLength;
+				currFuelUsage += static_cast<uint>(fuelUsage.usageMove * vecLength);
 			}
 			if (item->iCount >= currFuelUsage)
 			{
 				pub::Player::RemoveCargo(iClientID, item->sID, currFuelUsage);
 				return true;
 			}
+			break;
 		}
 	}
-
 	return false;
 }
 

--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -107,7 +107,7 @@ static map<uint, CLIENTCDSTRUCT> mapClientsCD;
 static map<uint, CLOAK_ARCH> mapCloakingDevices;
 static map<uint, CDSTRUCT> mapCloakDisruptors;
 
-static uint CloakAlertSound = CreateID("cloak_osiris");
+static uint cloakAlertSound = CreateID("cloak_osiris");
 static unordered_set<uint> setJumpingClients;
 
 void LoadSettings();
@@ -226,7 +226,7 @@ void LoadSettings()
 			else if (ini.is_header("General")) {
 				while (ini.read_value()) {
 					if (ini.is_value("cloak_alert_sound")) {
-						CloakAlertSound = CreateID(ini.get_value_string());
+						cloakAlertSound = CreateID(ini.get_value_string());
 					}
 				}
 			}
@@ -551,7 +551,7 @@ void HkTimerCheckKick()
 									}
 									if (isGroupMember)
 									{
-										pub::Audio::PlaySoundEffect(client2, CloakAlertSound);
+										pub::Audio::PlaySoundEffect(client2, cloakAlertSound);
 									}
 									else
 									{
@@ -562,7 +562,7 @@ void HkTimerCheckKick()
 								}
 								else
 								{
-									pub::Audio::PlaySoundEffect(client2, CloakAlertSound);
+									pub::Audio::PlaySoundEffect(client2, cloakAlertSound);
 								}
 							}
 

--- a/Source/FLHook/HkCbIClientImpl.cpp
+++ b/Source/FLHook/HkCbIClientImpl.cpp
@@ -1037,12 +1037,14 @@ bool HkIClientImpl::Send_FLPACKET_SERVER_SYSTEM_SWITCH_IN(uint iClientID, FLPACK
 /**************************************************************************************************************
 **************************************************************************************************************/
 
-bool HkIClientImpl::Send_FLPACKET_SERVER_SYSTEM_SWITCH_OUT(uint iClientID, FLPACKET_UNKNOWN &pDunno)
+bool HkIClientImpl::Send_FLPACKET_SERVER_SYSTEM_SWITCH_OUT(uint iClientID, FLPACKET_SYSTEM_SWITCH_OUT &switchOutPacket)
 {
 	ISERVER_LOG();
 	ISERVER_LOGARG_UI(iClientID);
 
-	CALL_CLIENT_METHOD(Send_FLPACKET_SERVER_SYSTEM_SWITCH_OUT(iClientID, pDunno));
+	CALL_PLUGINS(PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_SYSTEM_SWITCH_OUT, bool, __stdcall, (uint, FLPACKET_SYSTEM_SWITCH_OUT&), (iClientID, switchOutPacket));
+
+	CALL_CLIENT_METHOD(Send_FLPACKET_SERVER_SYSTEM_SWITCH_OUT(iClientID, switchOutPacket));
 	return reinterpret_cast<bool>(vRet);
 }
 

--- a/Source/FLHookPluginSDK/headers/FLCoreRemoteClient.h
+++ b/Source/FLHookPluginSDK/headers/FLCoreRemoteClient.h
@@ -41,6 +41,12 @@ struct FLPACKET_UNKNOWN
 	uint iDunno[20];
 };
 
+struct FLPACKET_SYSTEM_SWITCH_OUT
+{
+	uint shipId;
+	uint jumpObjectId;
+};
+
 struct FLPACKET_CREATEGUIDED
 {
 	uint iProjectileId;
@@ -191,7 +197,7 @@ public:
 	virtual bool Send_FLPACKET_COMMON_UPDATEOBJECT(uint iClientID, SSPObjUpdateInfo& pUpdate);
 	virtual bool Send_FLPACKET_SERVER_DESTROYOBJECT(uint iClientID, FLPACKET_DESTROYOBJECT& pDestroy);
 	virtual bool Send_FLPACKET_SERVER_ACTIVATEOBJECT(uint iClientID, XActivateEquip& aq);
-	virtual bool Send_FLPACKET_SERVER_SYSTEM_SWITCH_OUT(uint iClientID, FLPACKET_UNKNOWN& pDunno);
+	virtual bool Send_FLPACKET_SERVER_SYSTEM_SWITCH_OUT(uint iClientID, FLPACKET_SYSTEM_SWITCH_OUT& pSwitchOut);
 	virtual bool Send_FLPACKET_SERVER_SYSTEM_SWITCH_IN(uint iClientID, FLPACKET_UNKNOWN& pDunno);
 	virtual bool Send_FLPACKET_SERVER_LAND(uint iClientID, FLPACKET_LAND& pLand);
 	EXPORT virtual bool Send_FLPACKET_SERVER_LAUNCH(uint iClientID, FLPACKET_LAUNCH& pLaunch);

--- a/Source/FLHookPluginSDK/headers/plugin.h
+++ b/Source/FLHookPluginSDK/headers/plugin.h
@@ -209,6 +209,7 @@ enum PLUGIN_CALLBACKS
 	PLUGIN_LoadSettings,
 	PLUGIN_Plugin_Communication,
 	PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_CREATEGUIDED, // adding here to avoid breaking private plugins due to enum mismatch, can be moved in case of global plugin recompile
+	PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_SYSTEM_SWITCH_OUT,
 	PLUGIN_CALLBACKS_AMOUNT,
 };
 


### PR DESCRIPTION
By default it replaces the cloak alert sound with cloak entry sound, to restore that, put the following into cloak.cfg

[General]
cloak_alert_sound = dsy_jumpdrive_survey