### PR TITLE
Guided missile fix

### DIFF
--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -408,6 +408,20 @@ namespace HkIServerImpl
 		}
 	}
 
+	void __stdcall CreateGuided(uint iClientID, FLPACKET_CREATEGUIDED& createGuidedPacket)
+	{
+		uint clientID = HkGetClientIDByShip(createGuidedPacket.iOwner);
+		if (!clientID)
+			return;
+		uint targetId;
+		pub::SpaceObj::GetTarget(createGuidedPacket.iOwner, targetId);
+		if (targetId)
+			return;
+
+		const auto& projectile = reinterpret_cast<CGuided*>(CObject::Find(createGuidedPacket.iProjectileId, CObject::CGUIDED_OBJECT));
+		projectile->set_target(nullptr);
+	}
+
 	void __stdcall RequestEvent(int iIsFormationRequest, unsigned int iShip, unsigned int iDockTarget, unsigned int p4, unsigned long p5, unsigned int iClientID)
 	{
 		returncode = DEFAULT_RETURNCODE;
@@ -1666,6 +1680,7 @@ EXPORT PLUGIN_INFO* Get_PluginInfo()
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::StopTradelane, PLUGIN_HkIServerImpl_StopTradelane, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::CreateNewCharacter, PLUGIN_HkIServerImpl_CreateNewCharacter, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::DestroyCharacter, PLUGIN_HkIServerImpl_DestroyCharacter, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::CreateGuided, PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_CREATEGUIDED, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIEngine::Dock_Call, PLUGIN_HkCb_Dock_Call, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkCb_SendChat, PLUGIN_HkCb_SendChat, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&UserCmd_Process, PLUGIN_UserCmd_Process, 0));

--- a/Source/FLHook/HkCbIClientImpl.cpp
+++ b/Source/FLHook/HkCbIClientImpl.cpp
@@ -361,12 +361,14 @@ bool HkIClientImpl::Send_FLPACKET_SERVER_CREATECOUNTER(uint iClientID, FLPACKET_
 /**************************************************************************************************************
 **************************************************************************************************************/
 
-bool HkIClientImpl::Send_FLPACKET_SERVER_CREATEGUIDED(uint iClientID, FLPACKET_UNKNOWN& pDunno)
+bool HkIClientImpl::Send_FLPACKET_SERVER_CREATEGUIDED(uint iClientID, FLPACKET_CREATEGUIDED& createGuidedPacket)
 {
 	ISERVER_LOG();
 	ISERVER_LOGARG_UI(iClientID);
 
-	CALL_CLIENT_METHOD(Send_FLPACKET_SERVER_CREATEGUIDED(iClientID, pDunno));
+	CALL_PLUGINS(PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_CREATEGUIDED, bool, __stdcall, (uint, FLPACKET_CREATEGUIDED&), (iClientID, createGuidedPacket));
+
+	CALL_CLIENT_METHOD(Send_FLPACKET_SERVER_CREATEGUIDED(iClientID, createGuidedPacket));
 	return reinterpret_cast<bool>(vRet);
 }
 

--- a/Source/FLHookPluginSDK/headers/FLCoreRemoteClient.h
+++ b/Source/FLHookPluginSDK/headers/FLCoreRemoteClient.h
@@ -41,6 +41,18 @@ struct FLPACKET_UNKNOWN
 	uint iDunno[20];
 };
 
+struct FLPACKET_CREATEGUIDED
+{
+	uint iProjectileId;
+	Vector vPos;
+	Quaternion qOri;
+	uint iTargetId;
+	uint iDunno;
+	uint iMunitionId;
+	uint iDunno2; // zero (initial speed?)
+	uint iOwner;
+};
+
 struct FLPACKET_SETREPUTATION
 {
 	uint iSpaceID;
@@ -172,7 +184,7 @@ public:
 	virtual bool Send_FLPACKET_SERVER_CREATESHIP(uint iClientID, FLPACKET_CREATESHIP& pShip);
 	virtual bool Send_FLPACKET_SERVER_CREATELOOT(uint iClientID, FLPACKET_UNKNOWN& pDunno);
 	virtual bool Send_FLPACKET_SERVER_CREATEMINE(uint iClientID, FLPACKET_UNKNOWN& pDunno);
-	virtual bool Send_FLPACKET_SERVER_CREATEGUIDED(uint iClientID, FLPACKET_UNKNOWN& pDunno);
+	virtual bool Send_FLPACKET_SERVER_CREATEGUIDED(uint iClientID, FLPACKET_CREATEGUIDED& pDunno);
 	virtual bool Send_FLPACKET_SERVER_CREATECOUNTER(uint iClientID, FLPACKET_UNKNOWN& pDunno);
 	virtual void unknown_53(uint iClientID, FLPACKET_UNKNOWN& pDunno);
 	virtual void unknown_54(uint iClientID, uint iDunno, uint iDunno2, uint iDunno3);

--- a/Source/FLHookPluginSDK/headers/plugin.h
+++ b/Source/FLHookPluginSDK/headers/plugin.h
@@ -208,6 +208,7 @@ enum PLUGIN_CALLBACKS
 	PLUGIN_ProcessEvent_BEFORE,
 	PLUGIN_LoadSettings,
 	PLUGIN_Plugin_Communication,
+	PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_CREATEGUIDED, // adding here to avoid breaking private plugins due to enum mismatch, can be moved in case of global plugin recompile
 	PLUGIN_CALLBACKS_AMOUNT,
 };
 


### PR DESCRIPTION
stops playershot missiles from locking onto last selected target, when no target is selected.