### PR TITLE
Missiles: add configurable list of projectiles not triggering the alert

### DIFF
--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -140,9 +140,9 @@ void LoadSettings()
 					if (ini.is_value("DumbProjectile"))
 					{
 						setDumbProjectiles.insert(CreateID(ini.get_value_string(0)));
-          }
-        }
-      }
+					}
+				}
+			}
 			else if (ini.is_header("TradeLaneBan"))
 			{
 				while (ini.read_value())
@@ -156,7 +156,6 @@ void LoadSettings()
 		}
 		ini.close();
 	}
-
 	//JDDisruptAmmo = CreateID("dsy_torpedo_jd_ammo");
 
 	ZoneUtilities::ReadUniverse();

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -432,8 +432,9 @@ namespace HkIServerImpl
 
 	void __stdcall CreateGuided(uint iClientID, FLPACKET_CREATEGUIDED& createGuidedPacket)
 	{
-		uint clientID = HkGetClientIDByShip(createGuidedPacket.iOwner);
-		if (!clientID)
+		uint targetType;
+		pub::SpaceObj::GetType(createGuidedPacket.iOwner, targetType);
+		if (!(targetType & (OBJ_FIGHTER | OBJ_FREIGHTER | OBJ_TRANSPORT | OBJ_GUNBOAT | OBJ_CRUISER | OBJ_CAPITAL))) //GetTarget throws an exception for non-ship entities.
 			return;
 		uint targetId;
 		pub::SpaceObj::GetTarget(createGuidedPacket.iOwner, targetId);
@@ -444,11 +445,10 @@ namespace HkIServerImpl
 			projectile->set_target(nullptr);
 			createGuidedPacket.iTargetId = 0;
 		}
-		else if(setDumbProjectiles.count(createGuidedPacket.iMunitionId))
+		else if (setDumbProjectiles.count(createGuidedPacket.iMunitionId))
 		{
 			createGuidedPacket.iTargetId = 0; // prevents the 'incoming missile' warning client-side
 		}
-
 	}
 
 	void __stdcall RequestEvent(int iIsFormationRequest, unsigned int iShip, unsigned int iDockTarget, unsigned int p4, unsigned long p5, unsigned int iClientID)

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -18,6 +18,7 @@
 #include <math.h>
 #include <list>
 #include <set>
+#include <unordered_set>
 
 
 #include <PluginUtilities.h>
@@ -50,6 +51,8 @@ float set_iDockBroadcastRange = 9999;
 
 float set_fSpinProtectMass;
 float set_fSpinImpulseMultiplier;
+
+unordered_set<uint> setDumbProjectiles;
 
 /** A return code to indicate to FLHook if we want the hook processing to continue. */
 PLUGIN_RETURNCODE returncode;
@@ -122,6 +125,25 @@ void LoadSettings()
 	set_iDockBroadcastRange = IniGetF(scPluginCfgFile, "General", "DockBroadcastRange", 0);
 
 	set_bLocalTime = IniGetB(scPluginCfgFile, "General", "LocalTime", false);
+
+	INI_Reader ini;
+	if (ini.open(scPluginCfgFile.c_str(), false))
+	{
+		while (ini.read_header())
+		{
+			if (ini.is_header("MissileFix"))
+			{
+				while (ini.read_value())
+				{
+					if (ini.is_value("DumbProjectile"))
+					{
+						setDumbProjectiles.insert(CreateID(ini.get_value_string(0)));
+					}
+				}
+			}
+		}
+		ini.close();
+	}
 
 	//JDDisruptAmmo = CreateID("dsy_torpedo_jd_ammo");
 
@@ -415,11 +437,21 @@ namespace HkIServerImpl
 			return;
 		uint targetId;
 		pub::SpaceObj::GetTarget(createGuidedPacket.iOwner, targetId);
-		if (targetId)
-			return;
+		if (!targetId)
+		{
+			const auto& projectile = reinterpret_cast<CGuided*>(CObject::Find(createGuidedPacket.iProjectileId, CObject::CGUIDED_OBJECT));
+			projectile->set_target(nullptr);
+			createGuidedPacket.iTargetId = 0;
+		}
+		else
+		{
+			const auto& dumbProjectileMatch = setDumbProjectiles.find(createGuidedPacket.iMunitionId);
+			if (dumbProjectileMatch != setDumbProjectiles.end())
+			{
+				createGuidedPacket.iTargetId = 0; // prevents the 'incoming missile' warning client-side
+			}
+		}
 
-		const auto& projectile = reinterpret_cast<CGuided*>(CObject::Find(createGuidedPacket.iProjectileId, CObject::CGUIDED_OBJECT));
-		projectile->set_target(nullptr);
 	}
 
 	void __stdcall RequestEvent(int iIsFormationRequest, unsigned int iShip, unsigned int iDockTarget, unsigned int p4, unsigned long p5, unsigned int iClientID)

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -439,17 +439,14 @@ namespace HkIServerImpl
 		pub::SpaceObj::GetTarget(createGuidedPacket.iOwner, targetId);
 		if (!targetId)
 		{
+			//disable both tracking and incoming-missile alert
 			const auto& projectile = reinterpret_cast<CGuided*>(CObject::Find(createGuidedPacket.iProjectileId, CObject::CGUIDED_OBJECT));
 			projectile->set_target(nullptr);
 			createGuidedPacket.iTargetId = 0;
 		}
-		else
+		else if(setDumbProjectiles.count(createGuidedPacket.iMunitionId))
 		{
-			const auto& dumbProjectileMatch = setDumbProjectiles.find(createGuidedPacket.iMunitionId);
-			if (dumbProjectileMatch != setDumbProjectiles.end())
-			{
-				createGuidedPacket.iTargetId = 0; // prevents the 'incoming missile' warning client-side
-			}
+			createGuidedPacket.iTargetId = 0; // prevents the 'incoming missile' warning client-side
 		}
 
 	}


### PR DESCRIPTION
Uses: Flaks and 'dumbfire' missiles which are actually seekers purely due to better handling even without any actual tracking.