### PR TITLE
Converting project to VS2022

### DIFF
--- a/Plugins/PluginUtilities/PluginUtilities.cpp
+++ b/Plugins/PluginUtilities/PluginUtilities.cpp
@@ -110,7 +110,7 @@ CAccount* HkGetAccountByClientID(uint iClientID)
 float HkDistance3D(Vector v1, Vector v2)
 {
 	float sq1 = v1.x - v2.x, sq2 = v1.y - v2.y, sq3 = v1.z - v2.z;
-	return sqrt(sq1*sq1 + sq2 * sq2 + sq3 * sq3);
+	return sqrtf(sq1*sq1 + sq2 * sq2 + sq3 * sq3);
 }
 
 // Calculate the distance between the two vectors
@@ -123,7 +123,7 @@ float HkDistance3DByShip(uint iShip1, uint iShip2)
 	Matrix m2;
 	pub::SpaceObj::GetLocation(iShip2, v2, m2);
 	float sq1 = v1.x - v2.x, sq2 = v1.y - v2.y, sq3 = v1.z - v2.z;
-	return sqrt(sq1*sq1 + sq2 * sq2 + sq3 * sq3);
+	return sqrtf(sq1*sq1 + sq2 * sq2 + sq3 * sq3);
 }
 
 bool HkSetEquip(uint iClientID, const list<EquipDesc>& equip)
@@ -928,10 +928,10 @@ Vector MatrixToEuler(const Matrix& mat)
 Quaternion HkMatrixToQuaternion(Matrix m)
 {
 	Quaternion quaternion;
-	quaternion.w = sqrt(max(0, 1 + m.data[0][0] + m.data[1][1] + m.data[2][2])) / 2;
-	quaternion.x = sqrt(max(0, 1 + m.data[0][0] - m.data[1][1] - m.data[2][2])) / 2;
-	quaternion.y = sqrt(max(0, 1 - m.data[0][0] + m.data[1][1] - m.data[2][2])) / 2;
-	quaternion.z = sqrt(max(0, 1 - m.data[0][0] - m.data[1][1] + m.data[2][2])) / 2;
+	quaternion.w = sqrtf(max(0, 1 + m.data[0][0] + m.data[1][1] + m.data[2][2])) / 2;
+	quaternion.x = sqrtf(max(0, 1 + m.data[0][0] - m.data[1][1] - m.data[2][2])) / 2;
+	quaternion.y = sqrtf(max(0, 1 - m.data[0][0] + m.data[1][1] - m.data[2][2])) / 2;
+	quaternion.z = sqrtf(max(0, 1 - m.data[0][0] - m.data[1][1] + m.data[2][2])) / 2;
 	quaternion.x = (float)_copysign(quaternion.x, m.data[2][1] - m.data[1][2]);
 	quaternion.y = (float)_copysign(quaternion.y, m.data[0][2] - m.data[2][0]);
 	quaternion.z = (float)_copysign(quaternion.z, m.data[1][0] - m.data[0][1]);

--- a/Plugins/Public/JSONBuddy/JSONBuddy.vcxproj
+++ b/Plugins/Public/JSONBuddy/JSONBuddy.vcxproj
@@ -13,12 +13,12 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{097BFFBB-2BBE-4E16-B2FB-3ED8E90ECBD7}</ProjectGuid>
     <RootNamespace>JSONBuddy</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
@@ -85,8 +85,7 @@ copy /Y $(OutDir)$(TargetName).pdb  ..\..\..\Binaries\bin-vc14\flhook_plugins\pu
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>
-      </AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>A:\FLHookAingar\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Async</ExceptionHandling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/Plugins/Public/JSONBuddy/JSONBuddy.vcxproj
+++ b/Plugins/Public/JSONBuddy/JSONBuddy.vcxproj
@@ -85,7 +85,7 @@ copy /Y $(OutDir)$(TargetName).pdb  ..\..\..\Binaries\bin-vc14\flhook_plugins\pu
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>A:\FLHookAingar\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Async</ExceptionHandling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/Plugins/Public/MarketFucker/MarketFucker.vcxproj
+++ b/Plugins/Public/MarketFucker/MarketFucker.vcxproj
@@ -13,12 +13,12 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9ED72C7D-81FC-49F5-8709-0AB542113D3F}</ProjectGuid>
     <RootNamespace>MarketFucker</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/Plugins/Public/MiscellaneousCommands/MiscellaneousCommands.vcxproj
+++ b/Plugins/Public/MiscellaneousCommands/MiscellaneousCommands.vcxproj
@@ -13,13 +13,13 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C26DA99F-10F7-421B-AC31-EED1623E7B04}</ProjectGuid>
     <RootNamespace>misc</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>MiscellaneousCommands</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/Plugins/Public/__PLUGIN_TEMPLATE/Template.vcxproj
+++ b/Plugins/Public/__PLUGIN_TEMPLATE/Template.vcxproj
@@ -13,13 +13,13 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E7008BA7-4F75-4AF7-B25C-3A9A3287A88F}</ProjectGuid>
     <RootNamespace>Template</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>Template</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/Plugins/Public/alley/alley.vcxproj
+++ b/Plugins/Public/alley/alley.vcxproj
@@ -84,7 +84,7 @@ copy /Y $(OutDir)$(TargetName).pdb  ..\..\..\Binaries\bin-vc14\flhook_plugins\pu
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>A:\FLHookAingar\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Async</ExceptionHandling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/Plugins/Public/alley/alley.vcxproj
+++ b/Plugins/Public/alley/alley.vcxproj
@@ -13,12 +13,12 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DB39D53F-D243-4C8C-95CD-2101CCA7D20F}</ProjectGuid>
     <RootNamespace>alley</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
@@ -84,8 +84,7 @@ copy /Y $(OutDir)$(TargetName).pdb  ..\..\..\Binaries\bin-vc14\flhook_plugins\pu
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>
-      </AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>A:\FLHookAingar\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ExceptionHandling>Async</ExceptionHandling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/Plugins/Public/autobuy/Autobuy.vcxproj
+++ b/Plugins/Public/autobuy/Autobuy.vcxproj
@@ -13,13 +13,13 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B92D0FA9-093B-4DB0-9AFD-3AF72BD87AAE}</ProjectGuid>
     <RootNamespace>Autobuy</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>autobuy</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/Plugins/Public/balancemagic/Balance Magic Plugin.vc14.vcxproj
+++ b/Plugins/Public/balancemagic/Balance Magic Plugin.vc14.vcxproj
@@ -14,13 +14,13 @@
     <ProjectGuid>{2853796F-8AAF-4E93-A210-08EA11C63D6B}</ProjectGuid>
     <RootNamespace>Balance Magic Plugin</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>Balance Magic Plugin</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Plugins/Public/base_plugin/Base Plugin.vc14.vcxproj
+++ b/Plugins/Public/base_plugin/Base Plugin.vc14.vcxproj
@@ -114,7 +114,7 @@ copy /Y $(OutDir)$(TargetName).pdb  ..\..\..\Binaries\bin-vc14\flhook_plugins\pu
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>A:\FLHookAingar\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>

--- a/Plugins/Public/base_plugin/Base Plugin.vc14.vcxproj
+++ b/Plugins/Public/base_plugin/Base Plugin.vc14.vcxproj
@@ -14,13 +14,13 @@
     <ProjectGuid>{81D35B95-1CDD-4F58-A24C-E2EC47D43DD0}</ProjectGuid>
     <RootNamespace>Player Owned Base Plugin</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>Base Plugin</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -114,6 +114,7 @@ copy /Y $(OutDir)$(TargetName).pdb  ..\..\..\Binaries\bin-vc14\flhook_plugins\pu
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>A:\FLHookAingar\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -370,7 +370,7 @@ public:
 	uint base;
 
 	map<wstring, uint> last_login_attempt_time;
-	map<wstring, int> unsuccessful_logins_in_a_row;
+	map<wstring, uint> unsuccessful_logins_in_a_row;
 
 	// The list of administration passwords
 	list<BasePassword> passwords;

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -122,7 +122,7 @@ namespace PlayerCommands
 		_snwprintf(titleBuf, sizeof(titleBuf), L"Base Help : Page %d/%d", page + 1, numPages);
 
 		wchar_t buf[4000];
-		_snwprintf(buf, sizeof(buf), L"<RDL><PUSH/>%s<POP/></RDL>", pagetext);
+		_snwprintf(buf, sizeof(buf), L"<RDL><PUSH/>%ls<POP/></RDL>", pagetext.c_str());
 
 		HkChangeIDSString(client, 500000, titleBuf);
 		HkChangeIDSString(client, 500001, buf);

--- a/Plugins/Public/cloak_plugin/Cloak Plugin.vc14.vcxproj
+++ b/Plugins/Public/cloak_plugin/Cloak Plugin.vc14.vcxproj
@@ -14,13 +14,13 @@
     <ProjectGuid>{81A35B95-1CED-4F58-A24C-E2DC47D43DD0}</ProjectGuid>
     <RootNamespace>Cloak Plugin</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>Cloak Plugin</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Plugins/Public/commoditylimit/CommodityLimit.vcxproj
+++ b/Plugins/Public/commoditylimit/CommodityLimit.vcxproj
@@ -13,13 +13,13 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E7DFB061-5E6A-47DC-94C5-CCB169EA410A}</ProjectGuid>
     <RootNamespace>CommodityLimit</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>CommodityLimit</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/Plugins/Public/conn_plugin/Conn Plugin.vc14.vcxproj
+++ b/Plugins/Public/conn_plugin/Conn Plugin.vc14.vcxproj
@@ -14,13 +14,13 @@
     <ProjectGuid>{81D33B95-1CDD-4F58-A24C-E2EC47143DD0}</ProjectGuid>
     <RootNamespace>Connecticut Plugin</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>Conn Plugin</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Plugins/Public/dronebays/DroneBay.vcxproj
+++ b/Plugins/Public/dronebays/DroneBay.vcxproj
@@ -13,13 +13,13 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7DE3DF47-662F-4E34-9899-140F103D2D01}</ProjectGuid>
     <RootNamespace>DroneBays</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>DroneBays</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/Plugins/Public/event/Event.vcxproj
+++ b/Plugins/Public/event/Event.vcxproj
@@ -13,13 +13,13 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4B9AB78F-085B-4F29-8E03-99FCF081F273}</ProjectGuid>
     <RootNamespace>Event</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>event</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/Plugins/Public/getrep/Rep.vcxproj
+++ b/Plugins/Public/getrep/Rep.vcxproj
@@ -13,13 +13,13 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E7EB5672-90CC-4B88-A8A0-55BB6BBAE7F7}</ProjectGuid>
     <RootNamespace>Rep</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>Rep</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/Plugins/Public/help_expanded/Help.vcxproj
+++ b/Plugins/Public/help_expanded/Help.vcxproj
@@ -13,13 +13,13 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8CBF9EF0-324A-4699-8A26-C2999B99B225}</ProjectGuid>
     <RootNamespace>Help</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>Help</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/Plugins/Public/hookext_plugin/HookExt Plugin.vcxproj
+++ b/Plugins/Public/hookext_plugin/HookExt Plugin.vcxproj
@@ -15,12 +15,12 @@
     <ProjectGuid>{81D33B95-1DDD-4F58-A24C-E2EC4A143DD0}</ProjectGuid>
     <RootNamespace>ExtHook Plugin</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Plugins/Public/minecontrol_plugin/MineControl Plugin.vc14.vcxproj
+++ b/Plugins/Public/minecontrol_plugin/MineControl Plugin.vc14.vcxproj
@@ -15,12 +15,12 @@
     <ProjectGuid>{367D5EDC-F360-49E0-B652-587B9E22CF6C}</ProjectGuid>
     <RootNamespace>FLHook Example Plugin</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Plugins/Public/mobiledocking_plugin/MobileDocking Plugin.vc14.vcxproj
+++ b/Plugins/Public/mobiledocking_plugin/MobileDocking Plugin.vc14.vcxproj
@@ -14,13 +14,13 @@
     <ProjectGuid>{81A35B95-1CDD-4F58-A24C-E2DC47D43DD0}</ProjectGuid>
     <RootNamespace>MobileDocking Plugin</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>MobileDocking Plugin</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Plugins/Public/npc_control/npc.vcxproj
+++ b/Plugins/Public/npc_control/npc.vcxproj
@@ -13,13 +13,13 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7C84F18C-FE8C-4731-882D-05C237753A54}</ProjectGuid>
     <RootNamespace>NPC</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>npc</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/Plugins/Public/playercntl_plugin/HyperJump.cpp
+++ b/Plugins/Public/playercntl_plugin/HyperJump.cpp
@@ -1749,7 +1749,7 @@ namespace HyperJump
 				IObjInspectImpl *obj = HkGetInspect(iClientID);
 				if (obj)
 				{
-					HkLightFuse((IObjRW*)obj, BeaconFuse, 0, BeaconTime, 0);
+					HkLightFuse((IObjRW*)obj, BeaconFuse, 0, static_cast<float>(BeaconTime), 0);
 				}
 
 				BEACONTIMER bc;

--- a/Plugins/Public/playercntl_plugin/Message.cpp
+++ b/Plugins/Public/playercntl_plugin/Message.cpp
@@ -104,7 +104,7 @@ void SendLocalSystemChat(uint iFromClientID, const wstring &wscText)
 		pub::SpaceObj::GetLocation(iShip, vShipLoc, mShipDir);
 
 		// Cheat in the distance calculation. Ignore the y-axis.
-		float fDistance = sqrt(pow(vShipLoc.x - vFromShipLoc.x, 2) + pow(vShipLoc.z - vFromShipLoc.z, 2));
+		float fDistance = sqrtf(powf(vShipLoc.x - vFromShipLoc.x, 2) + powf(vShipLoc.z - vFromShipLoc.z, 2));
 
 		//Is player within scanner range (15K) of the sending char.
 		if (fDistance > set_iLocalChatRangeUtl)

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -71,7 +71,7 @@ namespace MiscCmds
 	map<string, uint> factions;
 
 	// Resetrep is not allowed if attempted within the resetrep time limit (in seconds)
-	int set_iResetrepTimeLimit = 0;
+	uint set_iResetrepTimeLimit = 0;
 
 	/// Local chat range
 	float set_iLocalChatRange = 9999;

--- a/Plugins/Public/playercntl_plugin/Player Control Plugin.vc14.vcxproj
+++ b/Plugins/Public/playercntl_plugin/Player Control Plugin.vc14.vcxproj
@@ -15,12 +15,12 @@
     <ProjectGuid>{9E084A9E-A8B9-4F64-8048-F3357839683E}</ProjectGuid>
     <RootNamespace>FLHook Example Plugin</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -111,6 +111,7 @@ copy /Y $(OutDir)$(TargetName).pdb  ..\..\..\Binaries\bin-vc14\flhook_plugins\pu
       <AssemblerOutput>AssemblyCode</AssemblerOutput>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>A:\FLHookAingar\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;psapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Plugins/Public/playercntl_plugin/Player Control Plugin.vc14.vcxproj
+++ b/Plugins/Public/playercntl_plugin/Player Control Plugin.vc14.vcxproj
@@ -111,7 +111,7 @@ copy /Y $(OutDir)$(TargetName).pdb  ..\..\..\Binaries\bin-vc14\flhook_plugins\pu
       <AssemblerOutput>AssemblyCode</AssemblerOutput>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>A:\FLHookAingar\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\Dependencies;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;psapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Plugins/Public/playercntl_plugin/ZoneUtilities.cpp
+++ b/Plugins/Public/playercntl_plugin/ZoneUtilities.cpp
@@ -63,21 +63,21 @@ static TransformMatrix SetupTransform(Vector &p, Vector &r)
 	// X-axis rotation matrix
 	TransformMatrix xmat;
 	xmat.d[0][0] = 1;        xmat.d[0][1] = 0;        xmat.d[0][2] = 0;        xmat.d[0][3] = 0;
-	xmat.d[1][0] = 0;        xmat.d[1][1] = cos(ax);  xmat.d[1][2] = sin(ax);  xmat.d[1][3] = 0;
-	xmat.d[2][0] = 0;        xmat.d[2][1] = -sin(ax); xmat.d[2][2] = cos(ax);  xmat.d[2][3] = 0;
+	xmat.d[1][0] = 0;        xmat.d[1][1] = cosf(ax);  xmat.d[1][2] = sinf(ax);  xmat.d[1][3] = 0;
+	xmat.d[2][0] = 0;        xmat.d[2][1] = -sinf(ax); xmat.d[2][2] = cosf(ax);  xmat.d[2][3] = 0;
 	xmat.d[3][0] = 0;        xmat.d[3][1] = 0;        xmat.d[3][2] = 0;        xmat.d[3][3] = 1;
 
 	// Y-axis rotation matrix
 	TransformMatrix ymat;
-	ymat.d[0][0] = cos(ay);  ymat.d[0][1] = 0;        ymat.d[0][2] = -sin(ay); ymat.d[0][3] = 0;
+	ymat.d[0][0] = cosf(ay);  ymat.d[0][1] = 0;        ymat.d[0][2] = -sinf(ay); ymat.d[0][3] = 0;
 	ymat.d[1][0] = 0;        ymat.d[1][1] = 1;        ymat.d[1][2] = 0;        ymat.d[1][3] = 0;
-	ymat.d[2][0] = sin(ay);  ymat.d[2][1] = 0;        ymat.d[2][2] = cos(ay);  ymat.d[2][3] = 0;
+	ymat.d[2][0] = sinf(ay);  ymat.d[2][1] = 0;        ymat.d[2][2] = cosf(ay);  ymat.d[2][3] = 0;
 	ymat.d[3][0] = 0;        ymat.d[3][1] = 0;        ymat.d[3][2] = 0;        ymat.d[3][3] = 1;
 
 	// Z-axis rotation matrix
 	TransformMatrix zmat;
-	zmat.d[0][0] = cos(az);  zmat.d[0][1] = sin(az);  zmat.d[0][2] = 0;        zmat.d[0][3] = 0;
-	zmat.d[1][0] = -sin(az); zmat.d[1][1] = cos(az);  zmat.d[1][2] = 0;        zmat.d[1][3] = 0;
+	zmat.d[0][0] = cosf(az);  zmat.d[0][1] = sinf(az);  zmat.d[0][2] = 0;        zmat.d[0][3] = 0;
+	zmat.d[1][0] = -sinf(az); zmat.d[1][1] = cosf(az);  zmat.d[1][2] = 0;        zmat.d[1][3] = 0;
 	zmat.d[2][0] = 0;        zmat.d[2][1] = 0;        zmat.d[2][2] = 1;        zmat.d[2][3] = 0;
 	zmat.d[3][0] = 0;        zmat.d[3][1] = 0;        zmat.d[3][2] = 0;        zmat.d[3][3] = 1;
 
@@ -276,7 +276,7 @@ bool ZoneUtilities::InZone(uint system, const Vector &pos, ZONE &rlz)
 			+ pos.z*lz.transform.d[2][2] + lz.transform.d[3][2];
 
 		// If r is less than/equal to 1 then the point is inside the ellipsoid.
-		float result = sqrt(powf(x / lz.size.x, 2) + powf(y / lz.size.y, 2) + powf(z / lz.size.z, 2));
+		float result = sqrtf(powf(x / lz.size.x, 2) + powf(y / lz.size.y, 2) + powf(z / lz.size.z, 2));
 		if (result <= 1)
 		{
 			rlz = lz;
@@ -310,7 +310,7 @@ bool ZoneUtilities::InDeathZone(uint system, const Vector &pos, ZONE &rlz)
 			+ pos.z*lz.transform.d[2][2] + lz.transform.d[3][2];
 
 		// If r is less than/equal to 1 then the point is inside the ellipsoid.
-		float result = sqrt(powf(x / lz.size.x, 2) + powf(y / lz.size.y, 2) + powf(z / lz.size.z, 2));
+		float result = sqrtf(powf(x / lz.size.x, 2) + powf(y / lz.size.y, 2) + powf(z / lz.size.z, 2));
 		if (result <= 1 && lz.damage > 250)
 		{
 			rlz = lz;

--- a/Plugins/Public/pvecontroller/Main.cpp
+++ b/Plugins/Public/pvecontroller/Main.cpp
@@ -384,7 +384,7 @@ bool UserCmd_Value(uint iClientID, const wstring &wscCmd, const wstring &wscPara
 {
 	float fShipValue = 0;
 	HKGetShipValue((const wchar_t*)Players.GetActiveCharacterName(iClientID), fShipValue);
-	PrintUserCmdText(iClientID, L"Ship value: $%s credits.", ToMoneyStr(fShipValue).c_str());
+	PrintUserCmdText(iClientID, L"Ship value: $%s credits.", ToMoneyStr(static_cast<int>(fShipValue)).c_str());
 
 	return true;
 }

--- a/Plugins/Public/pvecontroller/pvecontroller.vcxproj
+++ b/Plugins/Public/pvecontroller/pvecontroller.vcxproj
@@ -13,13 +13,13 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{22D02598-F2D3-495F-BBA9-72DC156DA723}</ProjectGuid>
     <RootNamespace>misc</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>PvE Controller</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>

--- a/Plugins/Public/tempban/Tempban Plugin.vc14.vcxproj
+++ b/Plugins/Public/tempban/Tempban Plugin.vc14.vcxproj
@@ -14,13 +14,13 @@
     <ProjectGuid>{01DE3D3D-0DA2-447E-8C03-B2A2FB03A0F5}</ProjectGuid>
     <RootNamespace>Tempban Plugin</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectName>Tempban Plugin</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Source/FLHook.vcxproj
+++ b/Source/FLHook.vcxproj
@@ -14,12 +14,12 @@
     <ProjectGuid>{FE6EB3C9-DA22-4492-AEC3-068C9553A623}</ProjectGuid>
     <RootNamespace>FLHook</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Source/FLHook/Hook.h
+++ b/Source/FLHook/Hook.h
@@ -377,7 +377,7 @@ struct MONEY_FIX
 	wstring		wscCharname;
 	int			iAmount;
 
-	bool operator==(MONEY_FIX mf1)
+	bool operator==(const MONEY_FIX& mf1) const
 	{
 		if (!wscCharname.compare(mf1.wscCharname))
 			return true;


### PR DESCRIPTION
Old bad, new better.
Also made all plugin projects with boost dependencies have the /dependencies folder added to external dependencies. Why weren't they already?

Plausible performance increase due to using newer compiler.

Test server is currently running VS2022 generated DLLs without any issues.