### PR TITLE
Jettison: Adjusting Alley notrade to allow partial jettison

### DIFF
--- a/Plugins/Public/alley/PlayerRestrictions.cpp
+++ b/Plugins/Public/alley/PlayerRestrictions.cpp
@@ -257,7 +257,7 @@ void LoadSettings()
 				{
 					if (ini.is_value("tr"))
 					{
-						notradelist[CreateID(ini.get_value_string(0))] = ini.get_value_float(1);
+						notradelist[CreateID(ini.get_value_string(0))] = min(1.0f, max( 0.0f, ini.get_value_float(1)));
 					}
 				}
 			}
@@ -1111,7 +1111,7 @@ void JettisonCargo(unsigned int iClientID, struct XJettisonCargo const &jc)
 			uint amountToJettison = static_cast<uint>(jc.iCount * noTradeGood->second);
 			PrintUserCmdText(iClientID, L"%u units of %ls jettisoned, %u units lost in the process.", jc.iCount, goodName.c_str(), jc.iCount - amountToJettison);
 			pub::Player::RemoveCargo(iClientID, static_cast<ushort>(jc.iSlot), jc.iCount);
-			if (amountToJettison) {
+			if (amountToJettison > 0) {
 				uint shipId;
 				uint sysId;
 				Vector pos;

--- a/Plugins/Public/alley/PlayerRestrictions.cpp
+++ b/Plugins/Public/alley/PlayerRestrictions.cpp
@@ -1119,6 +1119,7 @@ void JettisonCargo(unsigned int iClientID, struct XJettisonCargo const &jc)
 				pub::Player::GetSystem(iClientID, sysId);
 				pub::Player::GetShip(iClientID, shipId);
 				pub::SpaceObj::GetLocation(shipId, pos, ori);
+				pos.x += 30.0;
 				Server.MineAsteroid(sysId, pos, CreateID("lootcrate_ast_loot_metal"), item.iArchID, amountToJettison, iClientID);
 			}
 		}

--- a/Plugins/Public/alley/PlayerRestrictions.cpp
+++ b/Plugins/Public/alley/PlayerRestrictions.cpp
@@ -1109,7 +1109,7 @@ void JettisonCargo(unsigned int iClientID, struct XJettisonCargo const &jc)
 		else
 		{
 			uint amountToJettison = static_cast<uint>(jc.iCount * noTradeGood->second);
-			PrintUserCmdText(iClientID, L"%u units of %ls jettisonned, %u units lost in the process.", jc.iCount, goodName.c_str(), jc.iCount - amountToJettison);
+			PrintUserCmdText(iClientID, L"%u units of %ls jettisoned, %u units lost in the process.", jc.iCount, goodName.c_str(), jc.iCount - amountToJettison);
 			pub::Player::RemoveCargo(iClientID, static_cast<ushort>(jc.iSlot), jc.iCount);
 			if (amountToJettison) {
 				uint shipId;


### PR DESCRIPTION
Define a percentage of cargo that will be successfully jettisoned, rest will be lost. Default behavior for undefined percentage or a defined zero will be a standard jettison block.

Also made pulling names for error messages dynamic instead of relying on config.