### PR TITLE
EventUtility: allowing admins to set HP and set/unset fuses to players

### DIFF
--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -1466,7 +1466,7 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 		HyperJump::AdminCmd_Pull(cmds, cmds->ArgCharname(1));
 		return true;
 	}
-	if (IS_CMD("move"))
+	else if (IS_CMD("move"))
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		HyperJump::AdminCmd_Move(cmds, cmds->ArgFloat(1), cmds->ArgFloat(2), cmds->ArgFloat(3));
@@ -1564,6 +1564,30 @@ bool ExecuteCommandString_Callback(CCmds* cmds, const wstring &wscCmd)
 	{
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 		Rename::ReloadLockedShips();
+		return true;
+	}
+	else if (IS_CMD("sethp"))
+	{
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+		MiscCmds::AdminCmd_SetHP(cmds, cmds->ArgUInt(1), cmds->ArgStr(2));
+		return true;
+	}
+	else if (IS_CMD("setfuse"))
+	{
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+		MiscCmds::AdminCmd_SetFuse(cmds, cmds->ArgStr(1), cmds->ArgStr(2));
+		return true;
+	}
+	else if (IS_CMD("sethpfuse"))
+	{
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+		MiscCmds::AdminCmd_SetHPFuse(cmds, cmds->ArgUInt(1), cmds->ArgStr(2), cmds->ArgStr(3));
+		return true;
+	}
+	else if (IS_CMD("unsetfuse"))
+		{
+		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+		MiscCmds::AdminCmd_UnsetFuse(cmds, cmds->ArgStr(1), cmds->ArgStr(2));
 		return true;
 	}
 	return false;

--- a/Plugins/Public/playercntl_plugin/Main.h
+++ b/Plugins/Public/playercntl_plugin/Main.h
@@ -105,6 +105,10 @@ namespace MiscCmds
 	void AdminCmd_PlaySound(CCmds* cmds, const wstring &wscSoundname);
 	void AdminCmd_PlayNNM(CCmds* cmds, const wstring &wscSoundname);
 
+	void AdminCmd_SetHP(CCmds* cmds, uint hpPercentage, const wstring& charName);
+	void AdminCmd_SetHPFuse(CCmds* cmds, uint hpPercentage, const wstring& fuseName, const wstring& charName);
+	void AdminCmd_SetFuse(CCmds* cmds, const wstring& fuseName, const wstring& charName);
+	void AdminCmd_UnsetFuse(CCmds* cmds, const wstring& fuseName, const wstring& charName);
 }
 
 namespace IPBans

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -1001,6 +1001,7 @@ namespace MiscCmds
 		float percentage = static_cast<float>(hpPercentage) / 100;
 
 		SetPlayerHp(targetClient, percentage);
+		cmds->Print(L"OK\n");
 	}
 
 	void AdminCmd_SetHPFuse(CCmds * cmds, uint hpPercentage, const wstring & fuseName, const wstring& charName)
@@ -1016,6 +1017,7 @@ namespace MiscCmds
 
 		SetPlayerHp(targetClient, percentage);
 		SetPlayerFuse(targetClient, fuseId);
+		cmds->Print(L"OK\n");
 	}
 
 	void AdminCmd_SetFuse(CCmds * cmds, const wstring & fuseName, const wstring& charName)
@@ -1029,6 +1031,7 @@ namespace MiscCmds
 		uint fuseId = CreateID(wstos(fuseName).c_str());
 
 		SetPlayerFuse(targetClient, fuseId);
+		cmds->Print(L"OK\n");
 	}
 
 	void AdminCmd_UnsetFuse(CCmds * cmds, const wstring & fuseName, const wstring& charName)
@@ -1042,5 +1045,6 @@ namespace MiscCmds
 		uint fuseId = CreateID(wstos(fuseName).c_str());
 
 		UnsetPlayerFuse(targetClient, fuseId);
+		cmds->Print(L"OK\n");
 	}
 }

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -954,7 +954,7 @@ namespace MiscCmds
 
 	uint CheckAdminRightAndGetTargetClient(CCmds* cmds, const wstring& charName)
 	{
-		if (!(cmds->rights & RIGHT_EVENTMODE))
+		if (!(cmds->rights & RIGHT_SUPERADMIN))
 		{
 			cmds->Print(L"ERR No permission\n");
 			return 0;

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -930,8 +930,7 @@ namespace MiscCmds
 
 	void SetPlayerHp(uint clientId, float percentage)
 	{
-		Players[clientId].fRelativeHealth = percentage;
-		HookClient->Send_FLPACKET_SERVER_SETHULLSTATUS(clientId, percentage);
+		pub::SpaceObj::SetRelativeHealth(Players[clientId].iShipID, percentage);
 	}
 
 	void SetPlayerFuse(uint clientId, uint fuseId)
@@ -939,6 +938,7 @@ namespace MiscCmds
 		IObjInspectImpl *obj = HkGetInspect(clientId);
 		if (obj)
 		{
+			HkUnLightFuse((IObjRW*)obj, fuseId, 0.0f); // in case it's a one-time fuse, we want to pre-emptively remove the previous, lingering fuse.
 			HkLightFuse((IObjRW*)obj, fuseId, 0.0f, 0.0f, 0.0f);
 		}
 	}
@@ -982,7 +982,7 @@ namespace MiscCmds
 
 		uint targetShip;
 		pub::Player::GetShip(targetClient, targetShip);
-		if (!targetShip)
+		if (!targetClient || targetClient == -1 || !targetShip) // HkGetClientIDByShip returns 0, HkGetClientIdFromCharname returns -1
 		{
 			cmds->Print(L"ERR Incorrect shipname/target\n");
 			return 0;
@@ -998,7 +998,7 @@ namespace MiscCmds
 			return;
 		}
 
-		float percentage = hpPercentage / 100;
+		float percentage = static_cast<float>(hpPercentage) / 100;
 
 		SetPlayerHp(targetClient, percentage);
 	}
@@ -1011,7 +1011,7 @@ namespace MiscCmds
 			return;
 		}
 
-		float percentage = hpPercentage / 100;
+		float percentage = static_cast<float>(hpPercentage) / 100;
 		uint fuseId = CreateID(wstos(fuseName).c_str());
 
 		SetPlayerHp(targetClient, percentage);

--- a/Plugins/Public/playercntl_plugin/MiscCmds.cpp
+++ b/Plugins/Public/playercntl_plugin/MiscCmds.cpp
@@ -927,4 +927,120 @@ namespace MiscCmds
 		cmds->Print(L"OK\n");
 		return;
 	}
+
+	void SetPlayerHp(uint clientId, float percentage)
+	{
+		Players[clientId].fRelativeHealth = percentage;
+		HookClient->Send_FLPACKET_SERVER_SETHULLSTATUS(clientId, percentage);
+	}
+
+	void SetPlayerFuse(uint clientId, uint fuseId)
+	{
+		IObjInspectImpl *obj = HkGetInspect(clientId);
+		if (obj)
+		{
+			HkLightFuse((IObjRW*)obj, fuseId, 0.0f, 0.0f, 0.0f);
+		}
+	}
+
+	void UnsetPlayerFuse(uint clientId, uint fuseId)
+	{
+		IObjInspectImpl *obj = HkGetInspect(clientId);
+		if (obj)
+		{
+			HkUnLightFuse((IObjRW*)obj, fuseId, 0.0f);
+		}
+	}
+
+	uint CheckAdminRightAndGetTargetClient(CCmds* cmds, const wstring& charName)
+	{
+		if (!(cmds->rights & RIGHT_EVENTMODE))
+		{
+			cmds->Print(L"ERR No permission\n");
+			return 0;
+		}
+		uint targetClient = 0;
+		if (charName.empty())
+		{
+			wstring adminName = cmds->GetAdminName();
+			if (adminName.empty())
+			{
+				cmds->Print(L"ERR No shipname provided\n");
+				return 0;
+			}
+			uint clientId = HkGetClientIdFromCharname(adminName);
+			uint shipId;
+			uint targetId;
+			pub::Player::GetShip(clientId, shipId);
+			pub::SpaceObj::GetTarget(shipId, targetId);
+			targetClient = HkGetClientIDByShip(targetId);
+		}
+		else
+		{
+			targetClient = HkGetClientIdFromCharname(charName);
+		}
+
+		uint targetShip;
+		pub::Player::GetShip(targetClient, targetShip);
+		if (!targetShip)
+		{
+			cmds->Print(L"ERR Incorrect shipname/target\n");
+			return 0;
+		}
+		return targetClient;
+	}
+
+	void AdminCmd_SetHP(CCmds * cmds, uint hpPercentage, const wstring& charName)
+	{
+		uint targetClient = CheckAdminRightAndGetTargetClient(cmds, charName);
+		if (!targetClient)
+		{
+			return;
+		}
+
+		float percentage = hpPercentage / 100;
+
+		SetPlayerHp(targetClient, percentage);
+	}
+
+	void AdminCmd_SetHPFuse(CCmds * cmds, uint hpPercentage, const wstring & fuseName, const wstring& charName)
+	{
+		uint targetClient = CheckAdminRightAndGetTargetClient(cmds, charName);
+		if (!targetClient)
+		{
+			return;
+		}
+
+		float percentage = hpPercentage / 100;
+		uint fuseId = CreateID(wstos(fuseName).c_str());
+
+		SetPlayerHp(targetClient, percentage);
+		SetPlayerFuse(targetClient, fuseId);
+	}
+
+	void AdminCmd_SetFuse(CCmds * cmds, const wstring & fuseName, const wstring& charName)
+	{
+		uint targetClient = CheckAdminRightAndGetTargetClient(cmds, charName);
+		if (!targetClient)
+		{
+			return;
+		}
+
+		uint fuseId = CreateID(wstos(fuseName).c_str());
+
+		SetPlayerFuse(targetClient, fuseId);
+	}
+
+	void AdminCmd_UnsetFuse(CCmds * cmds, const wstring & fuseName, const wstring& charName)
+	{
+		uint targetClient = CheckAdminRightAndGetTargetClient(cmds, charName);
+		if (!targetClient)
+		{
+			return;
+		}
+
+		uint fuseId = CreateID(wstos(fuseName).c_str());
+
+		UnsetPlayerFuse(targetClient, fuseId);
+	}
 }


### PR DESCRIPTION
Allows for 'cinematic' damage on Admin-flown ships during events via changing their HP and setting/unsetting fuses directly via commands