### PR TITLE
TradeLane: Fix TL state desync bug when crossing systems. Add Trade Lane ban list for ship archs.

### DIFF
--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -422,12 +422,24 @@ namespace HkIServerImpl
 		projectile->set_target(nullptr);
 	}
 
-	void __stdcall RequestEvent(int iIsFormationRequest, unsigned int iShip, unsigned int iDockTarget, unsigned int p4, unsigned long p5, unsigned int iClientID)
+	void __stdcall RequestEvent(int iEventType, unsigned int iShip, unsigned int iDockTarget, unsigned int p4, unsigned long p5, unsigned int iClientID)
 	{
 		returncode = DEFAULT_RETURNCODE;
 		if (iClientID)
 		{
-			if (!iIsFormationRequest)
+			if (iEventType == 2) // Trade Lane dock
+			{
+				float shieldHp, shieldMax;
+				bool shieldUp;
+				pub::SpaceObj::GetShieldHealth(iDockTarget, shieldHp, shieldMax, shieldUp);
+				if (!shieldUp)
+				{
+					pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnvoice_trade_lane_disrupted"));
+					returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+					return;
+				}
+			}
+			else if (!iEventType)
 			{
 				uint iTargetTypeID;
 				pub::SpaceObj::GetType(iDockTarget, iTargetTypeID);

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -466,7 +466,6 @@ namespace HkIServerImpl
 				if (!shieldUp)
 				{
 					pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnvoice_trade_lane_disrupted"));
-					Server.RequestCancel(iEventType, iShip, iTargetObj, 0, iClientID);
 					returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 				}
 				else if (setLaneBannedShips.find(Players[iClientID].iShipArchetype) != setLaneBannedShips.end())

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -51,7 +51,9 @@ float set_iDockBroadcastRange = 9999;
 float set_fSpinProtectMass;
 float set_fSpinImpulseMultiplier;
 
-unordered_set<uint> setLaneBannedShips;
+// set of ships which cannot use TradeLane, and are blocked
+// from forming on other ships to bypass the block
+unordered_set<uint> setLaneAndFormationBannedShips;
 /** A return code to indicate to FLHook if we want the hook processing to continue. */
 PLUGIN_RETURNCODE returncode;
 
@@ -135,7 +137,7 @@ void LoadSettings()
 				{
 					if (ini.is_value("ship"))
 					{
-						setLaneBannedShips.insert(CreateID(ini.get_value_string(0)));
+						setLaneAndFormationBannedShips.insert(CreateID(ini.get_value_string(0)));
 					}
 				}
 			}
@@ -468,7 +470,7 @@ namespace HkIServerImpl
 					pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnvoice_trade_lane_disrupted"));
 					returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 				}
-				else if (setLaneBannedShips.find(Players[iClientID].iShipArchetype) != setLaneBannedShips.end())
+				else if (setLaneAndFormationBannedShips.find(Players[iClientID].iShipArchetype) != setLaneAndFormationBannedShips.end())
 				{
 					pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_trade_lane_access_denied"));
 					returncode = SKIPPLUGINS_NOFUNCTIONCALL;
@@ -482,7 +484,7 @@ namespace HkIServerImpl
 		if (iClientID)
 		{
 			if (iEventType == 1 // formation request
-				&& setLaneBannedShips.find(Players[iClientID].iShipArchetype) != setLaneBannedShips.end())
+				&& setLaneAndFormationBannedShips.find(Players[iClientID].iShipArchetype) != setLaneAndFormationBannedShips.end())
 			{
 				pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnv_formation_request_denied"));
 				// values copied from vanilla 'leaving formation' callout


### PR DESCRIPTION
When you jump into a system, you always see tradelanes as alive, even if they were disabled by an evil pirate a moment earlier. Without the fix, you could dock and escape with pirate having no counterplay or ability to chase.

Also adds a configurable list of ships banned from using trade lanes. Ships banned from using trade lanes also cannot form onto other ships, but can be formed onto. This was done to prevent 'formation trade lane' behavior from used as a bypass for the block.