### PR TITLE
Docking: More organic Dock_Call overrides

### DIFF
--- a/Plugins/Public/alley/PlayerRestrictions.cpp
+++ b/Plugins/Public/alley/PlayerRestrictions.cpp
@@ -1179,7 +1179,7 @@ void __stdcall PlayerLaunch_AFTER(unsigned int iShip, unsigned int client)
 	SCI::UpdatePlayerID(client);
 }
 
-int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget, int iCancel, enum DOCK_HOST_RESPONSE response)
+int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget, int& iCancel, enum DOCK_HOST_RESPONSE& response)
 {
 	returncode = DEFAULT_RETURNCODE;
 
@@ -1189,12 +1189,14 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget
 	{
 		if (!ADOCK::IsDockAllowed(iShip, iDockTarget, iClientID))
 		{
-			returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+			iCancel = -1;
+			response = DOCK_DENIED;
 			return 0;
 		}
 		if (!SCI::CanDock(iDockTarget, iClientID))
 		{
-			returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+			iCancel = -1;
+			response = DOCK_DENIED;
 			return 0;
 		}
 	}

--- a/Plugins/Public/alley/dockrestrict.cpp
+++ b/Plugins/Public/alley/dockrestrict.cpp
@@ -301,7 +301,6 @@ bool ADOCK::IsDockAllowed(uint iShip, uint iDockTarget, uint iClientID)
 		Universe::IBase *base = Universe::get_base(iID);
 		if (base)
 		{
-			pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("info_access_denied"));
 			PrintUserCmdText(iClientID, L"You are not allowed to dock on any base.");
 			return false;
 		}

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -1315,7 +1315,7 @@ void __stdcall SystemSwitchOutComplete(unsigned int iShip, unsigned int iClientI
 		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 }
 
-int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &base, int iCancel, enum DOCK_HOST_RESPONSE response)
+int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &base, int& iCancel, enum DOCK_HOST_RESPONSE& response)
 {
 	returncode = DEFAULT_RETURNCODE;
 
@@ -1353,8 +1353,8 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &base, int i
 					if (foundid == false)
 					{
 						PrintUserCmdText(client, L"ERR Unable to dock with this ID.");
-						pub::Player::SendNNMessage(client, pub::GetNicknameId("info_access_denied"));
-						returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+						iCancel = -1;
+						response = ACCESS_DENIED;
 						return 0;
 					}
 				}
@@ -1382,8 +1382,8 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &base, int i
 					if (foundclass == false)
 					{
 						PrintUserCmdText(client, L"ERR Unable to dock with a vessel of this type.");
-						pub::Player::SendNNMessage(client, pub::GetNicknameId("info_access_denied"));
-						returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+						iCancel = -1;
+						response = ACCESS_DENIED;
 						return 0;
 					}
 				}
@@ -1400,9 +1400,9 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &base, int i
 				const Universe::ISystem *iSys = Universe::get_system(pbase->destsystem);
 				wstring wscSysName = HkGetWStringFromIDS(iSys->strid_name);
 
-				//PrintUserCmdText(client, L"Jump to system=%s x=%0.0f y=%0.0f z=%0.0f\n", wscSysName.c_str(), pos.x, pos.y, pos.z);
 				AP::SwitchSystem(client, pbase->destsystem, pos, ornt);
-				returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+				iCancel = -1;
+				response = DOCK;
 				return 1;
 			}
 
@@ -1410,16 +1410,16 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &base, int i
 			if (pbase->shield_active_time)
 			{
 				PrintUserCmdText(client, L"Docking failed because base shield is active");
-				pub::Player::SendNNMessage(client, pub::GetNicknameId("info_access_denied"));
-				returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+				iCancel = -1;
+				response = ACCESS_DENIED;
 				return 0;
 			}
 
 			if (!IsDockingAllowed(pbase, client))
 			{
 				PrintUserCmdText(client, L"Docking at this base is restricted");
-				pub::Player::SendNNMessage(client, pub::GetNicknameId("info_access_denied"));
-				returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+				iCancel = -1;
+				response = ACCESS_DENIED;
 				return 0;
 			}
 

--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -887,7 +887,7 @@ void __stdcall JumpInComplete_AFTER(unsigned int iSystem, unsigned int iShip)
 	}
 }
 
-int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget, int iCancel, enum DOCK_HOST_RESPONSE response)
+int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget, int& iCancel, enum DOCK_HOST_RESPONSE& response)
 {
 	returncode = DEFAULT_RETURNCODE;
 

--- a/Plugins/Public/mobiledocking_plugin/Main.cpp
+++ b/Plugins/Public/mobiledocking_plugin/Main.cpp
@@ -411,7 +411,7 @@ void __stdcall PlayerLaunch_AFTER(unsigned int ship, unsigned int client)
 }
 
 // If this is a docking request at a player ship then process it.
-int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, int iCancel, enum DOCK_HOST_RESPONSE response)
+int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, int& iCancel, enum DOCK_HOST_RESPONSE& response)
 {
 	returncode = DEFAULT_RETURNCODE;
 
@@ -434,6 +434,8 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, in
 		if (!iTargetClientID || HkDistance3DByShip(iShip, iTargetShip) > 1000.0f)
 		{
 			PrintUserCmdText(client, L"Ship is out of range");
+			iCancel = -1;
+			response = DOCK_DENIED;
 			return 0;
 		}
 
@@ -441,6 +443,8 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, in
 		if (mobiledockClients[iTargetClientID].iDockingModulesAvailable == 0)
 		{
 			PrintUserCmdText(client, L"Target ship has no free docking capacity");
+			iCancel = -1;
+			response = DOCK_DENIED;
 			return 0;
 		}
 
@@ -449,6 +453,8 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, in
 		if (cship->shiparch()->fHoldSize > cargoCapacityLimit)
 		{
 			PrintUserCmdText(client, L"Target ship cannot dock a ship of your size.");
+			iCancel = -1;
+			response = DOCK_DENIED;
 			return 0;
 		}
 

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -312,7 +312,7 @@ string GetUserFilePath(const wstring &wscCharname, const string &scExtension)
 
 namespace HkIEngine
 {
-	int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget, int iCancel, enum DOCK_HOST_RESPONSE response)
+	int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget, int& iCancel, enum DOCK_HOST_RESPONSE& response)
 	{
 		returncode = DEFAULT_RETURNCODE;
 
@@ -326,8 +326,8 @@ namespace HkIEngine
 		else
 		{
 			if (Players[iClientID].fRelativeHealth == 0.0f && (iCancel != -1)) {
-				pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("dock_disallowed"));
-				returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+				iCancel = -1;
+				response = ACCESS_DENIED;
 				return 0;
 			}
 			uint iTypeID;
@@ -337,8 +337,9 @@ namespace HkIEngine
 				if (!IsDockingAllowed(iShip, iDockTarget, iClientID))
 				{
 					//AddLog("INFO: Docking suppressed docktarget=%u charname=%s", iDockTarget, wstos(Players.GetActiveCharacterName(iClientID)).c_str());
-					returncode = SKIPPLUGINS_NOFUNCTIONCALL;
-					return 0;
+					iCancel = -1;
+					response = ACCESS_DENIED;
+					return 1;
 				}
 
 				if (response == PROCEED_DOCK)

--- a/Source/FLHook/HkCbIEngine.cpp
+++ b/Source/FLHook/HkCbIEngine.cpp
@@ -130,14 +130,14 @@ namespace HkIEngine
 		//	p3 != -1, p4 -> 4 --> Dock ok, proceed (p3 Dock Port?)
 		//	p3 == -1, p4 -> 5 --> now DOCK!
 
-		CALL_PLUGINS(PLUGIN_HkCb_Dock_Call, int, , (unsigned int const &, unsigned int const &, int, DOCK_HOST_RESPONSE), (uShipID, uSpaceID, p3, p4));
+		CALL_PLUGINS(PLUGIN_HkCb_Dock_Call, int, , (unsigned int const &, unsigned int const &, int&, DOCK_HOST_RESPONSE&), (uShipID, uSpaceID, p3, p4));
 
 		try {
 			return pub::SpaceObj::Dock(uShipID, uSpaceID, p3, p4);
 		}
 		catch (...) { LOG_EXCEPTION }
 
-		CALL_PLUGINS(PLUGIN_HkCb_Dock_Call_AFTER, int, , (unsigned int const &, unsigned int const &, int, DOCK_HOST_RESPONSE), (uShipID, uSpaceID, p3, p4));
+		CALL_PLUGINS(PLUGIN_HkCb_Dock_Call_AFTER, int, , (unsigned int const &, unsigned int const &, int&, DOCK_HOST_RESPONSE&), (uShipID, uSpaceID, p3, p4));
 
 		return 0;
 	}


### PR DESCRIPTION
IMPORTANT: REQUIRES DOCK_CALL METHOD ADJUSTMENTS ON PRIVATE PLUGINS!

Sadly we're unable to cleanly override RequestEvent hook at the moment, as such this will not have effect on neutral-no-dock restriction.