### PR TITLE
Moving missile control to a separate plugin, selective tracking feature

### DIFF
--- a/FLHook.sln
+++ b/FLHook.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Template", "Plugins\Public\__PLUGIN_TEMPLATE\Template.vcxproj", "{E7008BA7-4F75-4AF7-B25C-3A9A3287A88F}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -71,30 +71,9 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MiscellaneousCommands", "Pl
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PvE Controller", "Plugins\Public\pvecontroller\pvecontroller.vcxproj", "{22D02598-F2D3-495F-BBA9-72DC156DA723}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MissileCntl", "Plugins\Public\missilecntl\missilecntl.vcxproj", "{F1EC36FB-0262-4EDD-B582-FE77872D3820}"
+EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{097bffbb-2bbe-4e16-b2fb-3ed8e90ecbd7}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{22d02598-f2d3-495f-bba9-72dc156da723}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{2853796f-8aaf-4e93-a210-08ea11c63d6b}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{367d5edc-f360-49e0-b652-587b9e22cf6c}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{45d41acc-2c3c-43d2-bc10-02aa73ffc7c7}*SharedItemsImports = 9
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{4b9ab78f-085b-4f29-8e03-99fcf081f273}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{7c84f18c-fe8c-4731-882d-05c237753a54}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{7de3df47-662f-4e34-9899-140f103d2d01}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{81a35b95-1cdd-4f58-a24c-e2dc47d43dd0}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{81a35b95-1ced-4f58-a24c-e2dc47d43dd0}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{81d33b95-1ddd-4f58-a24c-e2ec4a143dd0}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{81d35b95-1cdd-4f58-a24c-e2ec47d43dd0}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{8cbf9ef0-324a-4699-8a26-c2999b99b225}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{9e084a9e-a8b9-4f64-8048-f3357839683e}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{9ed72c7d-81fc-49f5-8709-0ab542113d3f}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{b92d0fa9-093b-4db0-9afd-3af72bd87aae}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{c26da99f-10f7-421b-ac31-eed1623e7b04}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{db39d53f-d243-4c8c-95cd-2101cca7d20f}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{e7008ba7-4f75-4af7-b25c-3a9a3287a88f}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{e7dfb061-5e6a-47dc-94c5-ccb169ea410a}*SharedItemsImports = 4
-		Plugins\PluginUtilities\PluginUtilities.vcxitems*{e7eb5672-90cc-4b88-a8a0-55bb6bbae7f7}*SharedItemsImports = 4
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		DebugDONOTUSE|Win32 = DebugDONOTUSE|Win32
 		DebugDONOTUSE|x64 = DebugDONOTUSE|x64
@@ -265,6 +244,14 @@ Global
 		{22D02598-F2D3-495F-BBA9-72DC156DA723}.Release|Win32.ActiveCfg = Release|Win32
 		{22D02598-F2D3-495F-BBA9-72DC156DA723}.Release|Win32.Build.0 = Release|Win32
 		{22D02598-F2D3-495F-BBA9-72DC156DA723}.Release|x64.ActiveCfg = Release|Win32
+		{F1EC36FB-0262-4EDD-B582-FE77872D3820}.DebugDONOTUSE|Win32.ActiveCfg = Debug|Win32
+		{F1EC36FB-0262-4EDD-B582-FE77872D3820}.DebugDONOTUSE|Win32.Build.0 = Debug|Win32
+		{F1EC36FB-0262-4EDD-B582-FE77872D3820}.DebugDONOTUSE|x64.ActiveCfg = Debug|Win32
+		{F1EC36FB-0262-4EDD-B582-FE77872D3820}.DebugDONOTUSE|x64.Build.0 = Debug|Win32
+		{F1EC36FB-0262-4EDD-B582-FE77872D3820}.Release|Win32.ActiveCfg = Release|Win32
+		{F1EC36FB-0262-4EDD-B582-FE77872D3820}.Release|Win32.Build.0 = Release|Win32
+		{F1EC36FB-0262-4EDD-B582-FE77872D3820}.Release|x64.ActiveCfg = Release|Win32
+		{F1EC36FB-0262-4EDD-B582-FE77872D3820}.Release|x64.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -295,8 +282,33 @@ Global
 		{2853796F-8AAF-4E93-A210-08EA11C63D6B} = {F77D3998-A163-4D75-95E3-88C3C6B2DCFA}
 		{C26DA99F-10F7-421B-AC31-EED1623E7B04} = {F77D3998-A163-4D75-95E3-88C3C6B2DCFA}
 		{22D02598-F2D3-495F-BBA9-72DC156DA723} = {F77D3998-A163-4D75-95E3-88C3C6B2DCFA}
+		{F1EC36FB-0262-4EDD-B582-FE77872D3820} = {F77D3998-A163-4D75-95E3-88C3C6B2DCFA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {393C1DF6-B2DC-4FF2-8100-36DD1F304E10}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{097bffbb-2bbe-4e16-b2fb-3ed8e90ecbd7}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{22d02598-f2d3-495f-bba9-72dc156da723}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{2853796f-8aaf-4e93-a210-08ea11c63d6b}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{367d5edc-f360-49e0-b652-587b9e22cf6c}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{45d41acc-2c3c-43d2-bc10-02aa73ffc7c7}*SharedItemsImports = 9
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{4b9ab78f-085b-4f29-8e03-99fcf081f273}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{7c84f18c-fe8c-4731-882d-05c237753a54}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{7de3df47-662f-4e34-9899-140f103d2d01}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{81a35b95-1cdd-4f58-a24c-e2dc47d43dd0}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{81a35b95-1ced-4f58-a24c-e2dc47d43dd0}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{81d33b95-1ddd-4f58-a24c-e2ec4a143dd0}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{81d35b95-1cdd-4f58-a24c-e2ec47d43dd0}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{8cbf9ef0-324a-4699-8a26-c2999b99b225}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{9e084a9e-a8b9-4f64-8048-f3357839683e}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{9ed72c7d-81fc-49f5-8709-0ab542113d3f}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{b92d0fa9-093b-4db0-9afd-3af72bd87aae}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{c26da99f-10f7-421b-ac31-eed1623e7b04}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{db39d53f-d243-4c8c-95cd-2101cca7d20f}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{e7008ba7-4f75-4af7-b25c-3a9a3287a88f}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{e7dfb061-5e6a-47dc-94c5-ccb169ea410a}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{e7eb5672-90cc-4b88-a8a0-55bb6bbae7f7}*SharedItemsImports = 4
+		Plugins\PluginUtilities\PluginUtilities.vcxitems*{f1ec36fb-0262-4edd-b582-fe77872d3820}*SharedItemsImports = 4
 	EndGlobalSection
 EndGlobal

--- a/Plugins/Public/missilecntl/Main.cpp
+++ b/Plugins/Public/missilecntl/Main.cpp
@@ -96,9 +96,9 @@ void LoadSettings()
 					{
 						missileArch = CreateID(ini.get_value_string(0));
 					}
-					else if (ini.is_value("ShipType"))
+					else if (ini.is_value("DontTrackShipType"))
 					{
-						string typeStr = ini.get_value_string(0);
+						string typeStr = ToLower(ini.get_value_string(0));
 						if (typeStr == "fighter")
 							blacklistedShipTypesBitmap |= OBJ_FIGHTER;
 						else if (typeStr == "freighter")

--- a/Plugins/Public/missilecntl/Main.cpp
+++ b/Plugins/Public/missilecntl/Main.cpp
@@ -1,0 +1,191 @@
+// MissileControl Plugin - Handle tracking/alert notifications for missile projectiles
+// By Aingar
+//
+// This is free software; you can redistribute it and/or modify it as
+// you wish without restriction. If you do then I would appreciate
+// being notified and/or mentioned somewhere.
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//Includes
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <unordered_set>
+#include <unordered_map>
+#include <FLHook.h>
+#include <plugin.h>
+#include <PluginUtilities.h>
+
+#include "../hookext_plugin/hookext_exports.h"
+
+map<string, uint> factions;
+/// A return code to indicate to FLHook if we want the hook processing to continue.
+PLUGIN_RETURNCODE returncode;
+
+unordered_set<uint> setNoTrackingAlertProjectiles;
+
+unordered_map<uint, uint> mapTrackingByShiptypeBlacklistBitmap;
+
+enum TRACKING_STATE {
+	TRACK_ALERT,
+	TRACK_NOALERT,
+	NOTRACK_NOALERT
+};
+
+void LoadSettings();
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+	srand((uint)time(0));
+	// If we're being loaded from the command line while FLHook is running then
+	// set_scCfgFile will not be empty so load the settings as FLHook only
+	// calls load settings on FLHook startup and .rehash.
+	if (fdwReason == DLL_PROCESS_ATTACH)
+	{
+		if (set_scCfgFile.length() > 0)
+			LoadSettings();
+	}
+	else if (fdwReason == DLL_PROCESS_DETACH)
+	{
+	}
+	return true;
+}
+
+/// Hook will call this function after calling a plugin function to see if we the
+/// processing to continue
+EXPORT PLUGIN_RETURNCODE Get_PluginReturnCode()
+{
+	return returncode;
+}
+
+bool bPluginEnabled = true;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//Loading Settings
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void LoadSettings()
+{
+	returncode = DEFAULT_RETURNCODE;
+
+	INI_Reader ini;
+
+	char szCurDir[MAX_PATH];
+	GetCurrentDirectory(sizeof(szCurDir), szCurDir);
+	string scPluginCfgFile = string(szCurDir) + "\\flhook_plugins\\missilecntl.cfg";
+	if (ini.open(scPluginCfgFile.c_str(), false))
+	{
+		while (ini.read_header())
+		{
+			if (ini.is_header("General"))
+			{
+				while (ini.read_value())
+				{
+					if (ini.is_value("NoTrackingAlertProjectile"))
+					{
+						setNoTrackingAlertProjectiles.insert(CreateID(ini.get_value_string(0)));
+					}
+				}
+			}
+			else if (ini.is_header("TrackingBlacklistByShipType"))
+			{
+				uint missileArch = 0;
+				uint blacklistedShipTypesBitmap = 0;
+				while (ini.read_value())
+				{
+					if (ini.is_value("MissileArch"))
+					{
+						missileArch = CreateID(ini.get_value_string(0));
+					}
+					else if (ini.is_value("ShipType"))
+					{
+						string typeStr = ini.get_value_string(0);
+						if (typeStr == "fighter")
+							blacklistedShipTypesBitmap |= OBJ_FIGHTER;
+						else if (typeStr == "freighter")
+							blacklistedShipTypesBitmap |= OBJ_FREIGHTER;
+						else if (typeStr == "transport")
+							blacklistedShipTypesBitmap |= OBJ_TRANSPORT;
+						else if (typeStr == "gunboat")
+							blacklistedShipTypesBitmap |= OBJ_GUNBOAT;
+						else if (typeStr == "cruiser")
+							blacklistedShipTypesBitmap |= OBJ_CRUISER;
+						else if (typeStr == "capital")
+							blacklistedShipTypesBitmap |= OBJ_CAPITAL;
+						else
+							ConPrint(L"MissileCntl: Error reading config for Blacklisted munitions, value %ls not recognized\n", stows(typeStr).c_str());
+					}
+				}
+				mapTrackingByShiptypeBlacklistBitmap[missileArch] = blacklistedShipTypesBitmap;
+			}
+		}
+		ini.close();
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//Functions
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void __stdcall CreateGuided(uint iClientID, FLPACKET_CREATEGUIDED& createGuidedPacket)
+{
+	uint ownerType;
+	pub::SpaceObj::GetType(createGuidedPacket.iOwner, ownerType);
+	if (!(ownerType & (OBJ_FIGHTER | OBJ_FREIGHTER | OBJ_TRANSPORT | OBJ_GUNBOAT | OBJ_CRUISER | OBJ_CAPITAL))) //GetTarget throws an exception for non-ship entities.
+		return;
+	uint targetId;
+	pub::SpaceObj::GetTarget(createGuidedPacket.iOwner, targetId);
+
+	TRACKING_STATE tracking = TRACK_ALERT;
+
+	if (!targetId) // prevent missiles from tracking cloaked ships, and missiles sticking targeting to last selected target
+	{
+		tracking = NOTRACK_NOALERT;
+	}
+	else if (setNoTrackingAlertProjectiles.count(createGuidedPacket.iMunitionId)) // for 'dumbified' seeker missiles, disable alert, used for flaks and snub dumbfires
+	{
+		tracking = TRACK_NOALERT;
+	}
+	else if (mapTrackingByShiptypeBlacklistBitmap.count(createGuidedPacket.iMunitionId)) // disable tracking for selected ship types
+	{
+		uint targetType;
+		pub::SpaceObj::GetType(createGuidedPacket.iTargetId, targetType);
+		const auto& blacklistedShipTypeTargets = mapTrackingByShiptypeBlacklistBitmap.at(createGuidedPacket.iMunitionId);
+		if(blacklistedShipTypeTargets & targetType)
+		{
+			tracking = NOTRACK_NOALERT;
+		}
+	}
+
+	switch (tracking)
+	{
+		case NOTRACK_NOALERT:
+		{
+			const auto& projectile = reinterpret_cast<CGuided*>(CObject::Find(createGuidedPacket.iProjectileId, CObject::CGUIDED_OBJECT));
+			projectile->set_target(nullptr); //disable tracking, switch fallthrough to also disable alert
+		}
+		case TRACK_NOALERT:
+		{
+			createGuidedPacket.iTargetId = 0; // prevents the 'incoming missile' warning client-side
+		}
+	}
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//Functions to hook
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+EXPORT PLUGIN_INFO* Get_PluginInfo()
+{
+	PLUGIN_INFO* p_PI = new PLUGIN_INFO();
+	p_PI->sName = "Missile Controller";
+	p_PI->sShortName = "missilecntl";
+	p_PI->bMayPause = true;
+	p_PI->bMayUnload = true;
+	p_PI->ePluginReturnCode = &returncode;
+
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&LoadSettings, PLUGIN_LoadSettings, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&CreateGuided, PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_CREATEGUIDED, 0));
+
+	return p_PI;
+}

--- a/Plugins/Public/missilecntl/missilecntl.vcxproj
+++ b/Plugins/Public/missilecntl/missilecntl.vcxproj
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{F1EC36FB-0262-4EDD-B582-FE77872D3820}</ProjectGuid>
+    <RootNamespace>MissileCntl</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
+    <ProjectName>MissileCntl</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+    <Import Project="..\..\PluginUtilities\PluginUtilities.vcxitems" Label="Shared" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>14.0.23107.0</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <IncludePath>$(SolutionDir)\Plugins\PluginUtilities;$(SolutionDir)\Source\FLHookPluginSDK\headers;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(ProjectDir)$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(SolutionDir)\Plugins\PluginUtilities;$(SolutionDir)\Source\FLHookPluginSDK\headers;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <TargetName>missilecntl</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+    <CustomBuildStep>
+      <Outputs>..\..\..\Binaries\bin-vc14\flhook_plugins\public\$(TargetName).dll;..\..\..\Binaries\bin-vc14\flhook_plugins\public\$(TargetName).pdb;%(Outputs)</Outputs>
+      <Command>copy /Y $(OutDir)$(TargetName).dll  ..\..\..\Binaries\bin-vc14\flhook_plugins\public\
+copy /Y $(OutDir)$(TargetName).pdb  ..\..\..\Binaries\bin-vc14\flhook_plugins\public\
+      </Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <CustomBuildStep>
+      <Command>copy /Y $(OutDir)$(TargetName).dll  ..\..\..\Binaries\bin-vc14\flhook_plugins\public\
+copy /Y $(OutDir)$(TargetName).pdb  ..\..\..\Binaries\bin-vc14\flhook_plugins\public\
+      </Command>
+      <Outputs>..\..\..\Binaries\bin-vc14\flhook_plugins\public\$(TargetName).dll;..\..\..\Binaries\bin-vc14\flhook_plugins\public\$(TargetName).pdb;%(Outputs)</Outputs>
+    </CustomBuildStep>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <PrecompiledHeader />
+    </ClCompile>
+    <Link>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <AdditionalLibraryDirectories>$(SolutionDir)\Dependencies\boost\lib32-msvc-14.1;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>$(SolutionDir)/Plugins/Public/hookext_plugin/release/ahookext.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Source\FLHook.vcxproj">
+      <Project>{fe6eb3c9-da22-4492-aec3-068c9553a623}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Plugins/Public/missilecntl/missilecntl.vcxproj.filters
+++ b/Plugins/Public/missilecntl/missilecntl.vcxproj.filters
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+</Project>

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -430,20 +430,6 @@ namespace HkIServerImpl
 		}
 	}
 
-	void __stdcall CreateGuided(uint iClientID, FLPACKET_CREATEGUIDED& createGuidedPacket)
-	{
-		uint clientID = HkGetClientIDByShip(createGuidedPacket.iOwner);
-		if (!clientID)
-			return;
-		uint targetId;
-		pub::SpaceObj::GetTarget(createGuidedPacket.iOwner, targetId);
-		if (targetId)
-			return;
-
-		const auto& projectile = reinterpret_cast<CGuided*>(CObject::Find(createGuidedPacket.iProjectileId, CObject::CGUIDED_OBJECT));
-		projectile->set_target(nullptr);
-	}
-
 	void __stdcall RequestEvent(int iEventType, unsigned int iShip, unsigned int iTargetObj, unsigned int p4, unsigned long p5, unsigned int iClientID)
 	{
 		returncode = DEFAULT_RETURNCODE;
@@ -1757,7 +1743,6 @@ EXPORT PLUGIN_INFO* Get_PluginInfo()
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::StopTradelane, PLUGIN_HkIServerImpl_StopTradelane, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::CreateNewCharacter, PLUGIN_HkIServerImpl_CreateNewCharacter, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::DestroyCharacter, PLUGIN_HkIServerImpl_DestroyCharacter, 0));
-	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::CreateGuided, PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_CREATEGUIDED, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIEngine::Dock_Call, PLUGIN_HkCb_Dock_Call, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkCb_SendChat, PLUGIN_HkCb_SendChat, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&UserCmd_Process, PLUGIN_UserCmd_Process, 0));

--- a/Source/FLHookPluginSDK/headers/FLCoreRemoteClient.h
+++ b/Source/FLHookPluginSDK/headers/FLCoreRemoteClient.h
@@ -84,7 +84,7 @@ struct FLPACKET_BURNFUSE
 struct FLPACKET_DESTROYOBJECT
 {
 	uint iSpaceID;
-	uint iDestroyType;
+	DestroyType iDestroyType;
 };
 
 struct FLPACKET_CREATESHIP


### PR DESCRIPTION
Moved from PlayerCntl as it was starting to bloat, and might expand more in the future.
Added ability to set specific missile types to be unable to track selected ship classes. For example: Cruiser missiles unable to track snubs.

Includes #206 changes as well.