### PR TITLE
Dock_Call bugfixes

### DIFF
--- a/Plugins/Public/mobiledocking_plugin/Main.cpp
+++ b/Plugins/Public/mobiledocking_plugin/Main.cpp
@@ -411,13 +411,13 @@ void __stdcall PlayerLaunch_AFTER(unsigned int ship, unsigned int client)
 }
 
 // If this is a docking request at a player ship then process it.
-int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, int& iCancel, enum DOCK_HOST_RESPONSE& response)
+int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, int& dockPort, enum DOCK_HOST_RESPONSE& response)
 {
 	returncode = DEFAULT_RETURNCODE;
 
 	//if not a player dock, skip
 	uint client = HkGetClientIDByShip(iShip);
-	if (client && response == DOCK && iCancel == -1)
+	if (client && response == DOCK && dockPort == -1)
 	{
 		// If no target then ignore the request.
 		uint iTargetShip;
@@ -435,7 +435,7 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, in
 		if (!iTargetClientID || HkDistance3DByShip(iShip, iTargetShip) > 1000.0f)
 		{
 			PrintUserCmdText(client, L"Ship is out of range");
-			iCancel = -1;
+			dockPort = -1;
 			response = DOCK_DENIED;
 			return 0;
 		}
@@ -444,7 +444,7 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, in
 		if (mobiledockClients[iTargetClientID].iDockingModulesAvailable == 0)
 		{
 			PrintUserCmdText(client, L"Target ship has no free docking capacity");
-			iCancel = -1;
+			dockPort = -1;
 			response = DOCK_DENIED;
 			return 0;
 		}
@@ -454,7 +454,7 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, in
 		if (cship->shiparch()->fHoldSize > cargoCapacityLimit)
 		{
 			PrintUserCmdText(client, L"Target ship cannot dock a ship of your size.");
-			iCancel = -1;
+			dockPort = -1;
 			response = DOCK_DENIED;
 			return 0;
 		}

--- a/Plugins/Public/mobiledocking_plugin/Main.cpp
+++ b/Plugins/Public/mobiledocking_plugin/Main.cpp
@@ -415,8 +415,9 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, in
 {
 	returncode = DEFAULT_RETURNCODE;
 
-	UINT client = HkGetClientIDByShip(iShip);
-	if (client)
+	//if not a player dock, skip
+	uint client = HkGetClientIDByShip(iShip);
+	if (client && response == DOCK && iCancel == -1)
 	{
 		// If no target then ignore the request.
 		uint iTargetShip;
@@ -457,8 +458,6 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iBaseID, in
 			response = DOCK_DENIED;
 			return 0;
 		}
-
-		returncode = SKIPPLUGINS_NOFUNCTIONCALL;
 
 		// Create a docking request and send a notification to the target ship.
 		mapPendingDockingRequests[client] = iTargetClientID;

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -322,9 +322,9 @@ namespace HkIEngine
 			// NPC call, let the game handle it
 			return 0;
 		}
-		else
+		else if ((response == PROCEED_DOCK || response == DOCK) && iCancel != -1)
 		{
-			if (Players[iClientID].fRelativeHealth == 0.0f && (iCancel != -1)) {
+			if (Players[iClientID].fRelativeHealth == 0.0f) {
 				iCancel = -1;
 				response = ACCESS_DENIED;
 				return 0;
@@ -354,6 +354,7 @@ namespace HkIEngine
 			SystemSensor::Dock_Call(iShip, iDockTarget, iCancel, response);
 			return 0;
 		}
+		return 0;
 	}
 }
 

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -311,7 +311,7 @@ string GetUserFilePath(const wstring &wscCharname, const string &scExtension)
 
 namespace HkIEngine
 {
-	int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget, int& iCancel, enum DOCK_HOST_RESPONSE& response)
+	int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget, int& dockPort, enum DOCK_HOST_RESPONSE& response)
 	{
 		returncode = DEFAULT_RETURNCODE;
 
@@ -322,10 +322,10 @@ namespace HkIEngine
 			// NPC call, let the game handle it
 			return 0;
 		}
-		else if ((response == PROCEED_DOCK || response == DOCK) && iCancel != -1)
+		else if ((response == PROCEED_DOCK || response == DOCK) && dockPort != -1)
 		{
 			if (Players[iClientID].fRelativeHealth == 0.0f) {
-				iCancel = -1;
+				dockPort = -1;
 				response = ACCESS_DENIED;
 				return 0;
 			}
@@ -336,7 +336,7 @@ namespace HkIEngine
 				if (!IsDockingAllowed(iShip, iDockTarget, iClientID))
 				{
 					//AddLog("INFO: Docking suppressed docktarget=%u charname=%s", iDockTarget, wstos(Players.GetActiveCharacterName(iClientID)).c_str());
-					iCancel = -1;
+					dockPort = -1;
 					response = ACCESS_DENIED;
 					return 1;
 				}
@@ -351,7 +351,7 @@ namespace HkIEngine
 				}
 			}
 
-			SystemSensor::Dock_Call(iShip, iDockTarget, iCancel, response);
+			SystemSensor::Dock_Call(iTypeID, iClientID);
 			return 0;
 		}
 		return 0;

--- a/Plugins/Public/playercntl_plugin/Main.h
+++ b/Plugins/Public/playercntl_plugin/Main.h
@@ -286,7 +286,7 @@ namespace SystemSensor
 	void JumpInComplete(unsigned int iSystem, unsigned int iShip, unsigned int iClientID);
 	void GoTradelane(unsigned int iClientID, struct XGoTradelane const &xgt);
 	void StopTradelane(unsigned int iClientID, unsigned int p1, unsigned int p2, unsigned int p3);
-	void Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget, int iCancel, enum DOCK_HOST_RESPONSE response);
+	void Dock_Call(uint const& typeID, uint clientId);
 }
 
 #endif

--- a/Plugins/Public/playercntl_plugin/SystemSensor.cpp
+++ b/Plugins/Public/playercntl_plugin/SystemSensor.cpp
@@ -340,7 +340,7 @@ namespace SystemSensor
 	void Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget, int iCancel, enum DOCK_HOST_RESPONSE response)
 	{
 		uint iClientID = HkGetClientIDByShip(iShip);
-		if (iClientID && (response == PROCEED_DOCK || response == DOCK) && !iCancel)
+		if (iClientID)
 		{
 			uint iTypeID;
 			pub::SpaceObj::GetType(iDockTarget, iTypeID);

--- a/Plugins/Public/playercntl_plugin/SystemSensor.cpp
+++ b/Plugins/Public/playercntl_plugin/SystemSensor.cpp
@@ -337,21 +337,15 @@ namespace SystemSensor
 	}
 
 	// Record jump type.
-	void Dock_Call(unsigned int const &iShip, unsigned int const &iDockTarget, int iCancel, enum DOCK_HOST_RESPONSE response)
+	void Dock_Call(uint const &typeID, uint clientId)
 	{
-		uint iClientID = HkGetClientIDByShip(iShip);
-		if (iClientID)
+		if (typeID == OBJ_JUMP_GATE)
 		{
-			uint iTypeID;
-			pub::SpaceObj::GetType(iDockTarget, iTypeID);
-			if (iTypeID == OBJ_JUMP_GATE)
-			{
-				mapInfo[iClientID].bInJumpGate = true;
-			}
-			else
-			{
-				mapInfo[iClientID].bInJumpGate = false;
-			}
+			mapInfo[clientId].bInJumpGate = true;
+		}
+		else
+		{
+			mapInfo[clientId].bInJumpGate = false;
 		}
 	}
 

--- a/Source/FLHook/HkCbIEngine.cpp
+++ b/Source/FLHook/HkCbIEngine.cpp
@@ -15,6 +15,7 @@
 namespace HkIEngine
 {
 
+	bool bAbortEventRequest;
 	/**************************************************************************************************************
 	// ship create & destroy
 	**************************************************************************************************************/
@@ -122,24 +123,42 @@ namespace HkIEngine
 	/**************************************************************************************************************
 	**************************************************************************************************************/
 
-	int __cdecl Dock_Call(unsigned int const &uShipID, unsigned int const &uSpaceID, int p3, enum DOCK_HOST_RESPONSE p4)
+	int __cdecl Dock_Call(unsigned int const &uShipID, unsigned int const &uSpaceID, int iDockPort, enum DOCK_HOST_RESPONSE dockResponse)
 	{
 
-		//	p3 == -1, p4 -> 2 --> Dock Denied!
-		//	p3 == -1, p4 -> 3 --> Dock in Use
-		//	p3 != -1, p4 -> 4 --> Dock ok, proceed (p3 Dock Port?)
-		//	p3 == -1, p4 -> 5 --> now DOCK!
+		//	iDockPort == -1, dockResponse -> 2 --> Dock Denied!
+		//	iDockPort == -1, dockResponse -> 3 --> Dock in Use
+		//	iDockPort != -1, dockResponse -> 4 --> Dock ok, proceed
+		//	iDockPort == -1, dockResponse -> 5 --> now DOCK!
 
-		CALL_PLUGINS(PLUGIN_HkCb_Dock_Call, int, , (unsigned int const &, unsigned int const &, int&, DOCK_HOST_RESPONSE&), (uShipID, uSpaceID, p3, p4));
+		DOCK_HOST_RESPONSE prePluginResponse = dockResponse;
+		int prePluginDockPort = iDockPort;
+
+		int returnValue;
+
+		CALL_PLUGINS(PLUGIN_HkCb_Dock_Call, int, , (unsigned int const &, unsigned int const &, int&, DOCK_HOST_RESPONSE&), (uShipID, uSpaceID, iDockPort, dockResponse));
 
 		try {
-			return pub::SpaceObj::Dock(uShipID, uSpaceID, p3, p4);
+			returnValue = pub::SpaceObj::Dock(uShipID, uSpaceID, iDockPort, dockResponse);
 		}
 		catch (...) { LOG_EXCEPTION }
 
-		CALL_PLUGINS(PLUGIN_HkCb_Dock_Call_AFTER, int, , (unsigned int const &, unsigned int const &, int&, DOCK_HOST_RESPONSE&), (uShipID, uSpaceID, p3, p4));
+		CALL_PLUGINS(PLUGIN_HkCb_Dock_Call_AFTER, int, , (unsigned int const &, unsigned int const &, int&, DOCK_HOST_RESPONSE&), (uShipID, uSpaceID, iDockPort, dockResponse));
 
-		return 0;
+		//if original response was positive and new response is negative, set the dock event for immediate cancellation
+		//also ACCESS_DENIED response doesn't automatically trigger the appropriate voice line
+		if (prePluginDockPort != -1 && iDockPort == -1 &&
+			(uint)prePluginResponse >= 3 && (uint)dockResponse < 3)
+		{
+			bAbortEventRequest = true;
+			if (dockResponse == ACCESS_DENIED)
+			{
+				uint client = HkGetClientIDByShip(uShipID);
+				pub::Player::SendNNMessage(client, pub::GetNicknameId("info_access_denied"));
+			}
+		}
+
+		return returnValue;
 	}
 
 

--- a/Source/FLHook/HkCbIServerImpl.cpp
+++ b/Source/FLHook/HkCbIServerImpl.cpp
@@ -1768,6 +1768,13 @@ namespace HkIServerImpl
 		EXECUTE_SERVER_CALL(Server.RequestEvent(iType, iShip, iShipTarget, p4, p5, iClientID));
 
 		CALL_PLUGINS_V(PLUGIN_HkIServerImpl_RequestEvent_AFTER, __stdcall, (int iType, unsigned int iShip, unsigned int iShipTarget, unsigned int p4, unsigned long p5, unsigned int iClientID), (iType, iShip, iShipTarget, p4, p5, iClientID));
+		
+		//If Dock_Call plugin turns a successful dock into a failed one, we need to cancel the event
+		if (HkIEngine::bAbortEventRequest)
+		{
+			HkIEngine::bAbortEventRequest = false;
+			Server.RequestCancel(iType, iShip, 0, UINT_MAX, iClientID);
+		}
 	}
 
 	/**************************************************************************************************************

--- a/Source/FLHook/Hook.h
+++ b/Source/FLHook/Hook.h
@@ -711,6 +711,7 @@ namespace HkIEngine
 	extern FARPROC fpOldInitCShip;
 	extern FARPROC fpOldDestroyCShip;
 	extern FARPROC fpOldLoadRepCharFile;
+	extern bool bAbortEventRequest;
 }
 
 // HkTimers


### PR DESCRIPTION
Fixes the issue where without explicitly doing a Server.RequestCancel() on a docking request that was changed by a plugin from success to failure, causes the server to periodically (once every 90 seconds) to re-attempt the dock.

Also fixes the issue where ACCESS_DENIED status did not play an appropriate voiceline on its own. 