### PR TITLE
Siege weaponry dmg override

### DIFF
--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -586,8 +586,22 @@ float CoreModule::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 		// shield offline, return expected damage without modifications
 		return new_hitpoints;
 	}
-	
-	float damageTaken = ((curr_hitpoints - new_hitpoints) * (1 - base->shield_strength_multiplier));
+
+	float damageTaken;
+	if (!siegeWeaponryMap.empty())
+	{
+		const auto& siegeDamageIter = siegeWeaponryMap.find(iDmgMunitionID);
+		if(siegeDamageIter == siegeWeaponryMap.end())
+			return curr_hitpoints;
+		else
+		{
+			damageTaken = siegeDamageIter->second * (1 - base->shield_strength_multiplier);
+		}
+	}
+	else
+	{
+		damageTaken = ((curr_hitpoints - new_hitpoints) * (1 - base->shield_strength_multiplier));
+	}
 
 	base->damage_taken_since_last_threshold += damageTaken;
 	if (base->damage_taken_since_last_threshold >= base->base_shield_reinforcement_threshold) {

--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -591,10 +591,14 @@ float CoreModule::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 	if (!siegeWeaponryMap.empty())
 	{
 		const auto& siegeDamageIter = siegeWeaponryMap.find(iDmgMunitionID);
-		if(siegeDamageIter == siegeWeaponryMap.end())
+		if (siegeDamageIter == siegeWeaponryMap.end())
+		{
+			//Siege gun(s) defined, but this is not one of them, no damage dealt
 			return curr_hitpoints;
+		}
 		else
 		{
+			//Even with siege gun damage override, it still takes shield strength into the account
 			damageTaken = siegeDamageIter->second * (1 - base->shield_strength_multiplier);
 		}
 	}

--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -576,7 +576,8 @@ float CoreModule::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 {
 	base->SpaceObjDamaged(space_obj, attacking_space_obj, curr_hitpoints, new_hitpoints);
 	
-	if(base->shield_state == PlayerBase::SHIELD_STATE_OFFLINE){
+	if(base->shield_state == PlayerBase::SHIELD_STATE_OFFLINE)
+	{
 		// shield offline, return expected damage without modifications
 		return new_hitpoints;
 	}
@@ -599,16 +600,17 @@ float CoreModule::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 		else
 		{
 			//Even with siege gun damage override, it still takes shield strength into the account
-			damageTaken = siegeDamageIter->second * (1 - base->shield_strength_multiplier);
+			damageTaken = siegeDamageIter->second * (1.0f - base->shield_strength_multiplier);
 		}
 	}
 	else
 	{
-		damageTaken = ((curr_hitpoints - new_hitpoints) * (1 - base->shield_strength_multiplier));
+		damageTaken = ((curr_hitpoints - new_hitpoints) * (1.0f - base->shield_strength_multiplier));
 	}
 
 	base->damage_taken_since_last_threshold += damageTaken;
-	if (base->damage_taken_since_last_threshold >= base->base_shield_reinforcement_threshold) {
+	if (base->damage_taken_since_last_threshold >= base->base_shield_reinforcement_threshold)
+	{
 		base->damage_taken_since_last_threshold -= base->base_shield_reinforcement_threshold;
 		base->shield_strength_multiplier += shield_reinforcement_increment;
 	}

--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -575,16 +575,16 @@ bool CoreModule::Timer(uint time)
 float CoreModule::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints)
 {
 	base->SpaceObjDamaged(space_obj, attacking_space_obj, curr_hitpoints, new_hitpoints);
+	
+	if(base->shield_state == PlayerBase::SHIELD_STATE_OFFLINE){
+		// shield offline, return expected damage without modifications
+		return new_hitpoints;
+	}
 
 	if (base->shield_strength_multiplier >= 1.0f || isGlobalBaseInvulnerabilityActive || base->invulnerable == 1)
 	{
 		// base invulnerable, keep current health value
 		return curr_hitpoints;
-	}
-	
-	if(base->shield_state == PlayerBase::SHIELD_STATE_OFFLINE){
-		// shield offline, return expected damage without modifications
-		return new_hitpoints;
 	}
 
 	float damageTaken;

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -153,6 +153,9 @@ float siege_mode_damage_trigger_level = 8000000;
 //the distance between bases to share siege mod activation
 float siege_mode_chain_reaction_trigger_distance = 8000;
 
+//siege weaponry definitions
+unordered_map<uint, float> siegeWeaponryMap;
+
 uint GetAffliationFromClient(uint client)
 {
 	int rep;
@@ -618,6 +621,10 @@ void LoadSettingsActual()
 					else if (ini.is_value("banned_system"))
 					{
 						bannedSystemList.insert(CreateID(ini.get_value_string(0)));
+					}
+					else if (ini.is_value("siege_gun"))
+					{
+						siegeWeaponryMap[CreateID(ini.get_value_string(0))] = ini.get_value_float(1);
 					}
 				}
 			}
@@ -2146,19 +2153,6 @@ void __stdcall HkCb_AddDmgEntry(DamageList *dmg, unsigned short sID, float& newH
 		if (set_plugin_debug)
 			ConPrint(L"HkCb_AddDmgEntry[1] - invalid damage?\n");
 		return;
-	}
-
-	// Ask the combat magic plugin if we need to do anything differently
-	COMBAT_DAMAGE_OVERRIDE_STRUCT info;
-	info.iMunitionID = iDmgMunitionID;
-	info.fDamageMultiplier = 0.0f;
-	Plugin_Communication(COMBAT_DAMAGE_OVERRIDE, &info);
-
-	if (info.fDamageMultiplier != 0.0f)
-	{
-		newHealth = (curr - (curr - newHealth) * info.fDamageMultiplier);
-		if (newHealth < 0.0f)
-			newHealth = 0.0f;
 	}
 
 	// This call is for us, skip all plugins.

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -680,6 +680,8 @@ extern float siege_mode_damage_trigger_level;
 
 extern float siege_mode_chain_reaction_trigger_distance;
 
+extern unordered_map<uint, float> siegeWeaponryMap;
+
 // From EquipmentUtilities.cpp
 namespace EquipmentUtilities
 {


### PR DESCRIPTION
As long as base is shielded, only specific siege weapons are capable of dealing damage (during vulnerability window), unless no siege guns are defined.

Attacking with non-siege gun will still trigger a shield, however.