### PR TITLE
PingTarget: Now provides very aproximate ping

### DIFF
--- a/Plugins/Public/JSONBuddy/Main.cpp
+++ b/Plugins/Public/JSONBuddy/Main.cpp
@@ -197,6 +197,7 @@ USERCMD UserCmds[] =
 {
 	{ L"/ping", Condata::UserCmd_Ping, L"Usage: /ping" },
 	{ L"/pingtarget", Condata::UserCmd_PingTarget, L"Usage: /pingtarget" },
+	{ L"/pt", Condata::UserCmd_PingTarget, L"Usage: /pingtarget" },
 };
 
 

--- a/Plugins/Public/JSONBuddy/condata.cpp
+++ b/Plugins/Public/JSONBuddy/condata.cpp
@@ -451,6 +451,16 @@ bool Condata::UserCmd_Ping(uint iClientID, const wstring &wscCmd, const wstring 
 }
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+wstring ObfuscatePing(uint averagePing)
+{
+	if (averagePing <= 80)
+		return L"0-80ms ";
+	if (averagePing <= 160)
+		return L"80-160ms ";
+
+	return L">160ms ";
+}
+
 bool Condata::UserCmd_PingTarget(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
 {
 	if (!set_bPingCmd) {
@@ -493,7 +503,7 @@ bool Condata::UserCmd_PingTarget(uint iClientID, const wstring &wscCmd, const ws
 	if (ConData[iClientIDTarget].lstPing.size() < set_iPingKickFrame)
 		Response += L"n/a Fluct: n/a ";
 	else {
-		Response += L"[redacted] ";
+		Response += ObfuscatePing(ConData[iClientIDTarget].iAveragePing).c_str();
 		if (set_iPingKick > 0) {
 			Response += L"(Max: ";
 			Response += stows(itos(set_iPingKick)).c_str();

--- a/Plugins/Public/JSONBuddy/condata.cpp
+++ b/Plugins/Public/JSONBuddy/condata.cpp
@@ -72,6 +72,7 @@ void Condata::UserCmd_Help(uint iClientID, const wstring &wscParam)
 	if (set_bPingCmd) {
 		PrintUserCmdText(iClientID, L"/ping");
 		PrintUserCmdText(iClientID, L"/pingtarget");
+		PrintUserCmdText(iClientID, L"/pt");
 	}
 
 }


### PR DESCRIPTION
Current /pingtarget is not informative enough without any latency info.

With very loose thresholds it gives a general idea about the connection without risking exposing the player by noting a specific ping value.