### PR TITLE
Cloak rework: fuel, detection, clientside checks

### DIFF
--- a/Source/FLHookPluginSDK/headers/plugin.h
+++ b/Source/FLHookPluginSDK/headers/plugin.h
@@ -255,7 +255,8 @@ enum PLUGIN_MESSAGE
 	COMBAT_DAMAGE_OVERRIDE = 45,
 	CUSTOM_JUMP = 47,
 	CUSTOM_IS_IT_POB = 50,
-	CUSTOM_REVERSE_TRANSACTION = 48
+	CUSTOM_REVERSE_TRANSACTION = 48,
+	CUSTOM_CLOAK_ALERT = 60
 };
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -367,6 +368,11 @@ struct CUSTOM_JUMP_STRUCT
 struct CUSTOM_REVERSE_TRANSACTION_STRUCT
 {
 	uint iClientID;
+};
+
+struct CUSTOM_CLOAK_ALERT_STRUCT
+{
+	vector<uint> alertedGroupMembers;
 };
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
One-commit version of #233

List of changes:

Cloak fuel consumption scales with speed using a quadratic formula,.making standing still consume little fuel, and moving causing progressively larger consumption.

Cloaks now get disrupted via proximity to nongrouped player ship.

Cloaks still produce sound when within disruption range of a grouped ship

Cloak distance check moved clientside and massively increased in frequency for improved responsiveness and server performance