### PR TITLE
Destroy CLoot on collision

### DIFF
--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -588,8 +588,18 @@ namespace HkIServerImpl
 		returncode = DEFAULT_RETURNCODE;
 
 		// If spin protection is off, do nothing.
-		if (set_fSpinProtectMass == -1.0f)
+		if (!ci.dwTargetShip || set_fSpinProtectMass == -1.0f)
 			return;
+
+		uint type;
+		pub::SpaceObj::GetType(ci.dwTargetShip, type);
+
+		if (type == OBJ_LOOT)
+		{
+			pub::SpaceObj::Destroy(ci.dwTargetShip, DestroyType::FUSE);
+			returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+			return;
+		}
 
 		// If the target is not a player, do nothing.
 		//uint iClientIDTarget = HkGetClientIDByShip(ci.dwTargetShip);

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -52,6 +52,8 @@ float set_iDockBroadcastRange = 9999;
 float set_fSpinProtectMass;
 float set_fSpinImpulseMultiplier;
 
+float set_fMinCLootRoadkillSpeed = 25.0f;
+
 // set of ships which cannot use TradeLane, and are blocked
 // from forming on other ships to bypass the block
 unordered_set<uint> setLaneAndFormationBannedShips;
@@ -124,6 +126,8 @@ void LoadSettings()
 
 	set_iLocalChatRange = IniGetF(scPluginCfgFile, "General", "LocalChatRange", 0);
 	set_iDockBroadcastRange = IniGetF(scPluginCfgFile, "General", "DockBroadcastRange", 0);
+	
+	set_fMinCLootRoadkillSpeed = IniGetF(scPluginCfgFile, "General", "MinCLootRoadkillSpeed", 25.0f);
 
 	set_bLocalTime = IniGetB(scPluginCfgFile, "General", "LocalTime", false);
 
@@ -602,7 +606,7 @@ namespace HkIServerImpl
 			Vector V1, V2;
 			pub::SpaceObj::GetMotion(client_ship, V1, V2);
 			float playerSpeed = sqrtf(V1.x * V1.x + V1.y * V1.y + V1.z * V1.z);
-			if (playerSpeed > 35)
+			if (playerSpeed > set_fMinCLootRoadkillSpeed)
 			{
 				pub::SpaceObj::Destroy(ci.dwTargetShip, DestroyType::FUSE);
 				returncode = SKIPPLUGINS_NOFUNCTIONCALL;

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -594,10 +594,19 @@ namespace HkIServerImpl
 		uint type;
 		pub::SpaceObj::GetType(ci.dwTargetShip, type);
 
+		uint client_ship;
+		pub::Player::GetShip(iClientID, client_ship);
+
 		if (type == OBJ_LOOT)
 		{
-			pub::SpaceObj::Destroy(ci.dwTargetShip, DestroyType::FUSE);
-			returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+			Vector V1, V2;
+			pub::SpaceObj::GetMotion(client_ship, V1, V2);
+			float playerSpeed = sqrtf(V1.x * V1.x + V1.y * V1.y + V1.z * V1.z);
+			if (playerSpeed > 35)
+			{
+				pub::SpaceObj::Destroy(ci.dwTargetShip, DestroyType::FUSE);
+				returncode = SKIPPLUGINS_NOFUNCTIONCALL;
+			}
 			return;
 		}
 
@@ -608,9 +617,6 @@ namespace HkIServerImpl
 
 		float target_mass;
 		pub::SpaceObj::GetMass(ci.dwTargetShip, target_mass);
-
-		uint client_ship;
-		pub::Player::GetShip(iClientID, client_ship);
 
 		float client_mass;
 		pub::SpaceObj::GetMass(client_ship, client_mass);

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -593,8 +593,10 @@ namespace HkIServerImpl
 
 		// If spin protection is off, do nothing.
 		if (!ci.dwTargetShip || set_fSpinProtectMass == -1.0f)
+		{
 			return;
-
+		}
+		
 		uint type;
 		pub::SpaceObj::GetType(ci.dwTargetShip, type);
 


### PR DESCRIPTION
CLoot containers are effectively unmovable objects, causing any ship that tries to fly into one to either quickly bounce off in case of smaller ships, or spin violently in case of caps. This destroys the CLoot containers when collided at above-trivial speed (default 25, configurable)