### PR TITLE
Add max bot/batt check on ship purchase, sell the excess.

### DIFF
--- a/Plugins/Public/autobuy/Main.cpp
+++ b/Plugins/Public/autobuy/Main.cpp
@@ -914,6 +914,45 @@ void __stdcall PlayerLaunch_AFTER(unsigned int iShip, unsigned int iClientID)
 	CheckforStackables(iClientID);
 }
 
+bool SetShipArch(uint iClientID, uint ship)
+{
+	returncode = DEFAULT_RETURNCODE;
+
+	static uint botsArch = CreateID("ge_s_repair_01");
+	static uint battArch = CreateID("ge_s_battery_01");
+	const auto& shipData = Archetype::GetShip(ship);
+	int counter = 0;
+	for (const auto& eq : Players[iClientID].equipDescList.equip)
+	{
+		if (eq.iArchID == botsArch)
+		{
+			if (eq.iCount > shipData->iMaxNanobots)
+			{
+				uint botsToSell = eq.iCount - shipData->iMaxNanobots;
+				pub::Player::RemoveCargo(iClientID, eq.sID, botsToSell);
+				const GoodInfo* gi = GoodList::find_by_id(botsArch);
+				pub::Player::AdjustCash(iClientID, static_cast<int>(gi->fPrice * static_cast<float>(botsToSell)));
+			}
+			counter++;
+		}
+		if (eq.iArchID == battArch)
+		{
+			if (eq.iCount > shipData->iMaxShieldBats)
+			{
+				uint battsToSell = eq.iCount - shipData->iMaxNanobots;
+				pub::Player::RemoveCargo(iClientID, eq.sID, battsToSell);
+				const GoodInfo* gi = GoodList::find_by_id(battArch);
+				pub::Player::AdjustCash(iClientID, static_cast<int>(gi->fPrice * static_cast<float>(battsToSell)));
+			}
+			counter++;
+		}
+		if (counter == 2)
+		{
+			break;
+		}
+	}
+	return true;
+}
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //Client command processing
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -994,6 +1033,7 @@ EXPORT PLUGIN_INFO* Get_PluginInfo()
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&ClearClientInfo, PLUGIN_ClearClientInfo, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&UserCmd_Process, PLUGIN_UserCmd_Process, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&PlayerLaunch_AFTER, PLUGIN_HkIServerImpl_PlayerLaunch_AFTER, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&SetShipArch, PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_SETSHIPARCH, 0));
 
 	return p_PI;
 }

--- a/Plugins/Public/autobuy/Main.cpp
+++ b/Plugins/Public/autobuy/Main.cpp
@@ -935,7 +935,7 @@ bool SetShipArch(uint iClientID, uint ship)
 			}
 			counter++;
 		}
-		if (eq.iArchID == battArch)
+		else if (eq.iArchID == battArch)
 		{
 			if (eq.iCount > shipData->iMaxShieldBats)
 			{
@@ -946,7 +946,7 @@ bool SetShipArch(uint iClientID, uint ship)
 			}
 			counter++;
 		}
-		if (counter == 2)
+		if (counter == 2) // both bots and batts processed, early exit
 		{
 			break;
 		}

--- a/Source/FLHook/HkCbIClientImpl.cpp
+++ b/Source/FLHook/HkCbIClientImpl.cpp
@@ -995,6 +995,8 @@ bool HkIClientImpl::Send_FLPACKET_SERVER_SETSHIPARCH(uint iClientID, uint iShipA
 	ISERVER_LOG();
 	ISERVER_LOGARG_UI(iClientID);
 
+	CALL_PLUGINS(PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_SETSHIPARCH, bool, , (uint, uint), (iClientID, iShipArch));
+
 	CALL_CLIENT_METHOD(Send_FLPACKET_SERVER_SETSHIPARCH(iClientID, iShipArch));
 	return reinterpret_cast<bool>(vRet);
 }

--- a/Source/FLHookPluginSDK/headers/plugin.h
+++ b/Source/FLHookPluginSDK/headers/plugin.h
@@ -211,6 +211,7 @@ enum PLUGIN_CALLBACKS
 	PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_CREATEGUIDED, // adding here to avoid breaking private plugins due to enum mismatch, can be moved in case of global plugin recompile
 	PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_SYSTEM_SWITCH_OUT,
 	PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_LAND,
+	PLUGIN_HkIClientImpl_Send_FLPACKET_SERVER_SETSHIPARCH,
 	PLUGIN_CALLBACKS_AMOUNT,
 };
 


### PR DESCRIPTION
When buying a capital ship, game doesn't validate the bot/batt count on the new ship, letting people end up with a ship holding nanobots where none should be present. (one time only, but still)

This hook triggers only on new ship purchase, and upon detecting an excess of either bots or batts, removes the excess and reimburses the player the appropriate amount.