### PR TITLE
MobileDock: Fix system jump out detection.

### DIFF
--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -608,6 +608,10 @@ namespace HkIServerImpl
 	void __stdcall SystemSwitchOutComplete(unsigned int iShip, unsigned int iClientID)
 	{
 		returncode = DEFAULT_RETURNCODE;
+		if (iClientID != HkGetClientIDByShip(iShip))
+		{
+			return;
+		}
 		// Make player invincible to fix JHs/JGs near mine fields sometimes
 		// exploding player while jumping (in jump tunnel)
 		pub::SpaceObj::SetInvincible(iShip, true, true, 0);


### PR DESCRIPTION
SystemSwitchOutComplete turns out to actually be a packet-type hook, it sends info about a ship dissapearing into a jump tunnel to every player in range. As such, blindly assuming it is the iClientID that jumped out is false most of the time.