### PR TITLE
Tradelane: Fix the shield check nomad TradeLanes (they have no shield)

### DIFF
--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -486,7 +486,7 @@ namespace HkIServerImpl
 				float shieldHp, shieldMax;
 				bool shieldUp;
 				pub::SpaceObj::GetShieldHealth(iTargetObj, shieldHp, shieldMax, shieldUp);
-				if (!shieldUp)
+				if (shieldMax > 0.0f && !shieldUp)
 				{
 					pub::Player::SendNNMessage(iClientID, pub::GetNicknameId("nnvoice_trade_lane_disrupted"));
 					returncode = SKIPPLUGINS_NOFUNCTIONCALL;


### PR DESCRIPTION
Fixes bug introduced in #220

Nomad Trade Lanes are not disruptable and have no shields, hence the check would always fails the dock attempt when it should always succeed.