### PR TITLE
Cloak: Prevent disabling of cloak during activation sequence. Fix sub-zero fuel consumption logic.

### DIFF
--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -415,7 +415,7 @@ void PlayerLaunch_AFTER(unsigned int iShip, unsigned int iClientID)
 		cloakInfo.bCanCloak = true;
 		cloakInfo.iState = STATE_CLOAK_INVALID;
 		SetState(iClientID, iShip, STATE_CLOAK_OFF);
-		if (cloakInfo.arch->bBreakOnProximity)
+		if (cloakInfo.arch && cloakInfo.arch->bBreakOnProximity)
 		{
 			InitCloakInfo(iClientID, static_cast<uint>(mapClientsCloak[iClientID].arch->fRange));
 		}

--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -184,7 +184,7 @@ void LoadSettings()
 				if (!cloakArch)
 				{
 					ConPrint(L"Problem loading config for cloak %ls", stows(device.scNickName).c_str());
-					break;
+					continue;
 				}
 				device.activationPeriod = static_cast<int>(ceil(cloakArch->fCloakinTime * 1000));
 				mapCloakingDevices[CreateID(device.scNickName.c_str())] = device;

--- a/Plugins/Public/cloak_plugin/Cloak.cpp
+++ b/Plugins/Public/cloak_plugin/Cloak.cpp
@@ -74,7 +74,7 @@ struct CLOAK_INFO
 	bool bCanCloak;
 	mstime tmCloakTime;
 	uint iState;
-	float fuelUsageCounter;
+	float fuelUsageCounter = 0;
 	bool bAdmin;
 	int DisruptTime;
 
@@ -336,9 +336,12 @@ static bool ProcessFuel(uint iClientID, CLOAK_INFO &info, uint iShipID)
 			info.fuelUsageCounter += currFuelUsage;
 			uint totalFuelUsage = static_cast<uint>(max(info.fuelUsageCounter, 0.0f));
 			info.fuelUsageCounter -= static_cast<float>(totalFuelUsage);
-			if (totalFuelUsage && item->iCount >= totalFuelUsage)
+			if (item->iCount >= totalFuelUsage)
 			{
-				pub::Player::RemoveCargo(iClientID, item->sID, totalFuelUsage);
+				if (totalFuelUsage)
+				{
+					pub::Player::RemoveCargo(iClientID, item->sID, totalFuelUsage);
+				}
 				return true;
 			}
 			if(info.arch->mapFuelToUsage.size() == 1)


### PR DESCRIPTION
Done to prevent being able to activate cloak, then deactivate it to achieve a permanent transparency on your ship. The deactivation fails if done by a command, and in case of running out of fuel, is delayed until the sequence finishes.
Also, minor code optimization.