### PR TITLE
Mining allow deployment for low tier mining

### DIFF
--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -44,6 +44,8 @@ float minJumpDistance = 15000;
 float minDistanceMisc = 2500;
 float minOtherPOBDistance = 5000;
 
+unordered_set<uint> lowTierMiningCommoditiesSet;
+
 /// Deployment command cooldown trackimg
 unordered_map<uint, uint> deploymentCooldownMap;
 uint deploymentCooldownDuration = 60;
@@ -636,6 +638,10 @@ void LoadSettingsActual()
 					else if (ini.is_value("min_jump_distance"))
 					{
 						minJumpDistance = max(0.0f, ini.get_value_float(0));
+					}
+					else if (ini.is_value("low_tier_mining_exemption"))
+					{
+						lowTierMiningCommoditiesSet.insert(CreateID(ini.get_value_string()));
 					}
 					else if(ini.is_value("deployment_cooldown"))
 					{
@@ -2890,10 +2896,29 @@ bool ExecuteCommandString_Callback(CCmds* cmd, const wstring &args)
 
 		RIGHT_CHECK(RIGHT_BASES)
 
+
+		ConPrint(L"POB distance check for following settings:\n"
+			L"High Tier Mining: %um\n"
+			L"Planets: %um\n"
+			L"Solars: %um\n"
+			L"Trade Lanes: %um\n"
+			L"JH/JG: %um\n"
+			L"POBs: %um\n"
+			L"Other: %um\n",
+			static_cast<uint>(minMiningDistance),
+			static_cast<uint>(minPlanetDistance),
+			static_cast<uint>(minStationDistance),
+			static_cast<uint>(minLaneDistance),
+			static_cast<uint>(minJumpDistance),
+			static_cast<uint>(minOtherPOBDistance),
+			static_cast<uint>(minDistanceMisc));
+
 		for (const auto& base : player_bases)
 		{
 			if (base.second->basetype != "legacy" || base.second->invulnerable || !base.second->logic)
+			{
 				continue;
+			}
 
 			Vector& pos = base.second->position;
 			uint system = base.second->system;

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -646,6 +646,7 @@ extern float minLaneDistance;
 extern float minJumpDistance;
 extern float minDistanceMisc;
 extern float minOtherPOBDistance;
+extern unordered_set<uint> lowTierMiningCommoditiesSet;
 
 /// Deployment command cooldown trackimg
 extern unordered_map<uint, uint> deploymentCooldownMap;

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -4,7 +4,7 @@ PlayerBase::PlayerBase(uint client, const wstring &password, const wstring &the_
 	: basename(the_basename),
 	base(0), money(0), base_health(0),
 	base_level(1), defense_mode(0), proxy_base(0), affiliation(0), siege_mode(false),
-	repairing(false), shield_timeout(0), shield_state(PlayerBase::SHIELD_STATE_ONLINE),
+	shield_timeout(0), shield_state(PlayerBase::SHIELD_STATE_ONLINE),
 	shield_strength_multiplier(base_shield_strength), damage_taken_since_last_threshold(0)
 {
 	nickname = CreateBaseNickname(wstos(basename));
@@ -39,7 +39,7 @@ PlayerBase::PlayerBase(uint client, const wstring &password, const wstring &the_
 PlayerBase::PlayerBase(const string &the_path)
 	: path(the_path), base(0), money(0),
 	base_health(0), base_level(0), defense_mode(0), proxy_base(0), affiliation(0), siege_mode(false),
-	repairing(false), shield_timeout(0), shield_state(PlayerBase::SHIELD_STATE_ONLINE),
+	shield_timeout(0), shield_state(PlayerBase::SHIELD_STATE_ONLINE),
 	shield_strength_multiplier(base_shield_strength), damage_taken_since_last_threshold(0)
 {
 	// Load and spawn base modules

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -1967,6 +1967,11 @@ namespace PlayerCommands
 					continue;
 				}
 
+				if (set_lowTierMiningCommodities.count(zone->lootableZone->dynamic_loot_commodity))
+				{
+					continue;
+				}
+
 				float distance = pub::Zone::GetDistance(zone->iZoneID, pos); // returns distance from the nearest point at the edge of the zone, value is negative if you're within the zone.
 
 				if (distance <= 0)
@@ -2071,7 +2076,7 @@ namespace PlayerCommands
 						}
 						else
 						{
-							ConPrint(L"Base too close to %ls, Current: %um, Minimum distance: %um", HkGetWStringFromIDS(idsName).c_str(), static_cast<uint>(distance));
+							ConPrint(L"Base too close to %ls, Current: %um", HkGetWStringFromIDS(idsName).c_str(), static_cast<uint>(distance));
 						}
 						return false;
 					}

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -1967,7 +1967,7 @@ namespace PlayerCommands
 					continue;
 				}
 
-				if (set_lowTierMiningCommodities.count(zone->lootableZone->dynamic_loot_commodity))
+				if (lowTierMiningCommoditiesSet.count(zone->lootableZone->dynamic_loot_commodity))
 				{
 					continue;
 				}


### PR DESCRIPTION
-Allows admins to define fields containing select 'low tier' commodities to be exempt from the distance checking, for example water, oxygen, toxic waste.
-Adjusts printing for the 'checkBaseDistances' utility
-Contains a compile fix - removal of nonexistent repairing field from PlayerBase constructor