### PR TITLE
MobileDocking: Bugfixes and adjustments

### DIFF
--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -2916,7 +2916,7 @@ void Plugin_Communication_CallBack(PLUGIN_MESSAGE msg, void* data)
 	{
 		returncode = SKIPPLUGINS;
 		CUSTOM_BASE_BEAM_STRUCT* info = reinterpret_cast<CUSTOM_BASE_BEAM_STRUCT*>(data);
-			PlayerBase *base = GetPlayerBase(info->iTargetBaseID);
+		PlayerBase *base = GetPlayerBase(info->iTargetBaseID);
 		if (base)
 		{
 			returncode = SKIPPLUGINS;

--- a/Plugins/Public/conn_plugin/Main.cpp
+++ b/Plugins/Public/conn_plugin/Main.cpp
@@ -270,6 +270,15 @@ bool UserCmd_Process(uint client, const wstring &cmd)
 			PrintUserCmdText(client, L"ERR Cannot use command in this system or base");
 			return true;
 		}
+		CUSTOM_MOBILE_DOCK_CHECK_STRUCT info;
+		info.iClientID = client;
+		info.isMobileDocked = false;
+		Plugin_Communication(CUSTOM_MOBILE_DOCK_CHECK, &info);
+		if (info.isMobileDocked)
+		{
+			PrintUserCmdText(client, L"ERR Cannot go to connecticut while mobile docked");
+			return true;
+		}
 
 		if (!IsDockedClient(client))
 		{

--- a/Plugins/Public/playercntl_plugin/Rename.cpp
+++ b/Plugins/Public/playercntl_plugin/Rename.cpp
@@ -433,6 +433,10 @@ namespace Rename
 				wstring wscCharFileName;
 				HkGetCharFileName(o.wscCharname, wscCharFileName);
 
+				CUSTOM_RENAME_NOTIFICATION_STRUCT info;
+				info.currentName = o.wscCharname;
+				Plugin_Communication(CUSTOM_RENAME_NOTIFICATION, &info);
+
 				// Move the char file to a temporary one.
 				if (!::MoveFileExA(o.scSourceFile.c_str(), o.scDestFileTemp.c_str(),
 					MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
@@ -483,9 +487,6 @@ namespace Rename
 						MiscCmds::Resetrep_save_Time_limits_to_player_account(scRenameFile, wscCharFileNamesWhichAlreadyUsedResetRep);
 					}
 				}
-				CUSTOM_RENAME_NOTIFICATION_STRUCT info;
-				info.currentName = o.wscCharname;
-				Plugin_Communication(CUSTOM_RENAME_NOTIFICATION, &info);
 			}
 			catch (char *err)
 			{

--- a/Plugins/Public/playercntl_plugin/Rename.cpp
+++ b/Plugins/Public/playercntl_plugin/Rename.cpp
@@ -483,6 +483,9 @@ namespace Rename
 						MiscCmds::Resetrep_save_Time_limits_to_player_account(scRenameFile, wscCharFileNamesWhichAlreadyUsedResetRep);
 					}
 				}
+				CUSTOM_RENAME_NOTIFICATION_STRUCT info;
+				info.currentName = o.wscCharname;
+				Plugin_Communication(CUSTOM_RENAME_NOTIFICATION, &info);
 			}
 			catch (char *err)
 			{

--- a/Source/FLHookPluginSDK/headers/plugin.h
+++ b/Source/FLHookPluginSDK/headers/plugin.h
@@ -262,6 +262,7 @@ enum PLUGIN_MESSAGE
 	CUSTOM_MOBILE_DOCK_CHECK = 53,
 	CUSTOM_IN_WARP_CHECK = 54,
 	CUSTOM_CLOAK_CHECK = 56,
+	CUSTOM_RENAME_NOTIFICATION = 57,
 	CUSTOM_CLOAK_ALERT = 60
 };
 
@@ -345,12 +346,6 @@ struct CUSTOM_BASE_IS_IT_POB_STRUCT
 	bool bAnswer;
 };
 
-struct CUSTOM_BASE_LAST_DOCKED_STRUCT
-{
-	uint iClientID;
-	uint iLastDockedBaseID;
-};
-
 struct CLIENT_CLOAK_STRUCT
 {
 	uint iClientID;
@@ -426,6 +421,11 @@ struct CUSTOM_CLOAK_CHECK_STRUCT
 {
 	uint clientId;
 	bool isCloaked = false;
+};
+
+struct CUSTOM_RENAME_NOTIFICATION_STRUCT
+{
+	wstring currentName;
 };
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
-Renaming a character fires a cross plugin event that force lands it to last docked solar/POB.
-Unable to go to /conn while mobile docked. (being actually docked on a POB but actually mobiledocked but ACTUALLY on New Haven is just a bit much)
-Server crash fixes fixes related to incorrect clearing of the containers and miscounting a counter.