### PR TITLE
POBs: Indestructible POBs don't process damage taken.

### DIFF
--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -311,7 +311,7 @@ public:
 	void SiegeModChainReaction(uint client);
 	void SyncReputationForBaseObject(uint space_obj);
 
-	float SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints);
+	void SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints);
 
 	// The base nickname
 	string nickname;

--- a/Plugins/Public/base_plugin/PlayerBase.cpp
+++ b/Plugins/Public/base_plugin/PlayerBase.cpp
@@ -753,8 +753,12 @@ void PlayerBase::SiegeModChainReaction(uint client)
 }
 
 // Return true if 
-float PlayerBase::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints)
+void PlayerBase::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints)
 {
+	if (invulnerable)
+	{
+		return;
+	}
 	float incoming_damage = curr_hitpoints - new_hitpoints;
 
 	// Make sure that the attacking player is hostile.
@@ -823,6 +827,4 @@ float PlayerBase::SpaceObjDamaged(uint space_obj, uint attacking_space_obj, floa
 
 		this->shield_timeout = time(nullptr) + 60;
 	}
-
-	return 0.0f;
 }


### PR DESCRIPTION
Results in no wasted CPU cycles, and no shields being triggered. win-win.