### PR TITLE
(MustHave)POBCraft: Fix issues with refineries

### DIFF
--- a/Plugins/Public/base_plugin/BuildModule.cpp
+++ b/Plugins/Public/base_plugin/BuildModule.cpp
@@ -162,15 +162,17 @@ bool BuildModule::Timer(uint time)
 				case Module::TYPE_DEFENSE_3:
 					base->modules[i] = new DefenseModule(base, Module::TYPE_DEFENSE_3);
 					break;
-				default:
+				case Module::TYPE_FACTORY:
 					//check if factory
 					if (factoryNicknameToCraftTypeMap.count(active_recipe.nickname))
 					{
 						base->modules[i] = new FactoryModule(base, active_recipe.nickname);
 						break;
 					}
-					base->modules[i] = 0;
+					base->modules[i] = nullptr;
 					break;
+				 default:
+					base->modules[i] = nullptr;
 				}
 				base->Save();
 				delete this;

--- a/Plugins/Public/base_plugin/CoreModule.cpp
+++ b/Plugins/Public/base_plugin/CoreModule.cpp
@@ -295,34 +295,34 @@ bool CoreModule::Timer(uint time)
 			peopleToFeed += base->HasMarketItem(humanCargoType);
 		}
 
-		for (auto i : set_base_crew_consumption_items)
+		for (uint item : set_base_crew_consumption_items)
 		{
 			// Use water and oxygen.
-			if (base->HasMarketItem(i.first) >= peopleToFeed)
+			if (base->HasMarketItem(item) >= peopleToFeed)
 			{
-				base->RemoveMarketGood(i.first, peopleToFeed);
+				base->RemoveMarketGood(item, peopleToFeed);
 			}
 			else
 			{
-				base->RemoveMarketGood(i.first, base->HasMarketItem(i.first));
+				base->RemoveMarketGood(item, base->HasMarketItem(item));
 				passedFoodCheck = false;
 			}
 		}
 
 		// Humans use food but may eat one of a number of types.
 
-		for (auto& i : set_base_crew_food_items)
+		for (uint item : set_base_crew_food_items)
 		{
 			if (!peopleToFeed)
 			{
 				break;
 			}
 
-			uint food_available = base->HasMarketItem(i.first);
+			uint food_available = base->HasMarketItem(item);
 			if (food_available)
 			{
 				uint food_to_use = min(food_available, peopleToFeed);
-				base->RemoveMarketGood(i.first, food_to_use);
+				base->RemoveMarketGood(item, food_to_use);
 				peopleToFeed -= food_to_use;
 			}
 		}

--- a/Plugins/Public/base_plugin/FactoryModule.cpp
+++ b/Plugins/Public/base_plugin/FactoryModule.cpp
@@ -259,7 +259,7 @@ void FactoryModule::LoadState(INI_Reader& ini)
 	{
 		if (ini.is_value("type"))
 		{
-			factoryNickname = CreateID(ini.get_value_string(0));\
+			factoryNickname = CreateID(ini.get_value_string(0));
 			for (auto& craftType : factoryNicknameToCraftTypeMap[factoryNickname])
 			{
 				base->availableCraftList.insert(craftType);

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -60,8 +60,8 @@ int construction_credit_cost = 0;
 list<REPAIR_ITEM> set_base_repair_items;
 
 /// list of items used by human crew
-map<uint, uint> set_base_crew_consumption_items;
-map<uint, uint> set_base_crew_food_items;
+vector<uint> set_base_crew_consumption_items;
+vector<uint> set_base_crew_food_items;
 
 uint set_crew_check_frequency = 43200;
 
@@ -74,7 +74,7 @@ unordered_set<uint> humanCargoList;
 PLUGIN_RETURNCODE returncode;
 
 /// Global recipe map
-map<uint, RECIPE> recipeMap;
+unordered_map<uint, RECIPE> recipeMap;
 
 /// Maps of shortcut numbers to recipes to construct item.
 map<wstring, map<uint, RECIPE>> recipeCraftTypeNumberMap;
@@ -591,14 +591,12 @@ void LoadSettingsActual()
 					else if (ini.is_value("base_crew_consumption_item"))
 					{
 						uint good = CreateID(ini.get_value_string(0));
-						uint quantity = ini.get_value_int(1);
-						set_base_crew_consumption_items[good] = quantity;
+						set_base_crew_consumption_items.emplace_back(good);
 					}
 					else if (ini.is_value("base_crew_food_item"))
 					{
 						uint good = CreateID(ini.get_value_string(0));
-						uint quantity = ini.get_value_int(1);
-						set_base_crew_food_items[good] = quantity;
+						set_base_crew_food_items.emplace_back(good);
 					}
 					else if (ini.is_value("set_crew_check_frequency"))
 					{
@@ -711,6 +709,7 @@ void LoadSettingsActual()
 					if (ini.is_value("nickname"))
 					{
 						recipe.nickname = CreateID(ini.get_value_string(0));
+						recipe.nicknameString = ini.get_value_string(0);
 					}
 					else if (ini.is_value("infotext"))
 					{
@@ -728,7 +727,7 @@ void LoadSettingsActual()
 					{
 						recipe_number = ini.get_value_int(0);
 					}
-					else if (ini.is_value("shortcut_number"))
+					else if (ini.is_value("module_class"))
 					{
 						recipe.shortcut_number = ini.get_value_int(0);
 					}
@@ -767,6 +766,7 @@ void LoadSettingsActual()
 					if (ini.is_value("nickname"))
 					{
 						recipe.nickname = CreateID(ini.get_value_string(0));
+						recipe.nicknameString = ini.get_value_string(0);
 					}
 					else if (ini.is_value("produced_item"))
 					{

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -31,19 +31,19 @@ struct AICONFIG
 
 struct RECIPE
 {
-	RECIPE() : cooking_rate(0), credit_cost(0) {}
-	uint nickname;
+	uint nickname = 0;
+	string nicknameString = "";
 	vector<pair<uint, uint>> produced_items;
-	uint shortcut_number;
-	bool loop_production;
-	wstring infotext;
-	wstring craft_type;
-	uint cooking_rate;
+	uint shortcut_number = 0;
+	bool loop_production = false;
+	wstring infotext = L"";
+	wstring craft_type = L"";
+	uint cooking_rate = 0;
 	vector<pair<uint, uint>> consumed_items;
 	vector<pair<uint, uint>> catalyst_items;
 	vector<pair<uint, uint>> catalyst_workforce;
-	uint credit_cost;
-	uint reqlevel;
+	uint credit_cost = 0;
+	uint reqlevel = 0;
 	unordered_map<uint, float> affiliationBonus;
 };
 
@@ -109,10 +109,9 @@ public:
 	int mining;
 	static const int TYPE_BUILD = 0;
 	static const int TYPE_CORE = 1;
-	static const int TYPE_SHIELDGEN = 2;
+	static const int TYPE_FACTORY = 2;
 	static const int TYPE_STORAGE = 3;
 	static const int TYPE_DEFENSE_1 = 4;
-	static const int TYPE_FACTORY = 5;
 	static const int TYPE_DEFENSE_2 = 9;
 	static const int TYPE_DEFENSE_3 = 10;
 
@@ -408,7 +407,7 @@ public:
 	unordered_map<wstring, FactoryModule*> craftTypeTofactoryModuleMap;
 
 	// Available crafting types
-	unordered_set<wstring> availableCraftList;
+	set<wstring> availableCraftList;
 
 	// Path to base ini file.
 	string path;
@@ -612,7 +611,7 @@ extern POBSOUNDS pbsounds;
 extern int set_plugin_debug;
 
 /// Global recipe map
-extern map<uint, RECIPE> recipeMap;
+extern unordered_map<uint, RECIPE> recipeMap;
 /// Maps of shortcut numbers to recipes to construct item.
 extern map<wstring, map<uint, RECIPE>> recipeCraftTypeNumberMap;
 extern map<wstring, map<wstring, RECIPE>> recipeCraftTypeNameMap;
@@ -631,9 +630,9 @@ extern list<REPAIR_ITEM> set_base_repair_items;
 
 extern uint set_base_crew_type;
 
-extern map<uint, uint> set_base_crew_consumption_items;
+extern vector<uint> set_base_crew_consumption_items;
 
-extern map<uint, uint> set_base_crew_food_items;
+extern vector<uint> set_base_crew_food_items;
 
 extern uint set_crew_check_frequency;
 

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -1264,6 +1264,7 @@ namespace PlayerCommands
 			for (auto& craftType : factoryNicknameToCraftTypeMap[facMod->factoryNickname])
 			{
 				base->availableCraftList.erase(craftType);
+				base->craftTypeTofactoryModuleMap.erase(craftType);
 			}
 		}
 		delete base->modules[index];
@@ -1302,12 +1303,19 @@ namespace PlayerCommands
 		}
 
 		wstring& craftType = GetParam(args, ' ', 1);
+		int craftTypeNumber = ToInt(craftType);
+		if (craftTypeNumber && base->availableCraftList.size() <= craftTypeNumber)
+		{
+			craftType = *next(base->availableCraftList.begin(), craftTypeNumber - 1);
+		}
 		if (craftType == L"list")
 		{
 			PrintUserCmdText(client, L"Available crafting lists:");
-			for (wstring craftType : base->availableCraftList)
+			uint counter = 1;
+			for (const wstring& craftTypeName : base->availableCraftList)
 			{
-				PrintUserCmdText(client, L"|   %ls", craftType.c_str());
+				PrintUserCmdText(client, L"%u. %ls", counter, craftTypeName.c_str());
+				counter++;
 			}
 			return;
 		}
@@ -1877,30 +1885,30 @@ namespace PlayerCommands
 		PrintUserCmdText(client, L"Crew: %u onboard", crewItemCount);
 
 		PrintUserCmdText(client, L"Crew supplies:");
-		for (auto& i : set_base_crew_consumption_items)
+		for (uint item : set_base_crew_consumption_items)
 		{
-			const GoodInfo* gi = GoodList::find_by_id(i.first);
+			const GoodInfo* gi = GoodList::find_by_id(item);
 			if (!gi)
 			{
 				continue;
 			}
-			if (base->market_items.count(i.first))
+			if (base->market_items.count(item))
 			{
-				PrintUserCmdText(client, L"|    %s: %u/%u", HkGetWStringFromIDS(gi->iIDSName).c_str(), base->HasMarketItem(i.first), base->market_items[i.first].max_stock);
+				PrintUserCmdText(client, L"|    %s: %u/%u", HkGetWStringFromIDS(gi->iIDSName).c_str(), base->HasMarketItem(item), base->market_items[item].max_stock);
 			}
 			else
 			{
-				PrintUserCmdText(client, L"|    %s: %u/0", HkGetWStringFromIDS(gi->iIDSName).c_str(), base->HasMarketItem(i.first));
+				PrintUserCmdText(client, L"|    %s: %u/0", HkGetWStringFromIDS(gi->iIDSName).c_str(), base->HasMarketItem(item));
 			}
 		}
 
 		uint foodCount = 0;
 		uint maxFoodCount = 0;
-		for (auto& i : set_base_crew_food_items)
+		for (uint item : set_base_crew_food_items)
 		{
-			foodCount += base->HasMarketItem(i.first);
-			if (base->market_items.count(i.first))
-				maxFoodCount += base->market_items[i.first].max_stock;
+			foodCount += base->HasMarketItem(item);
+			if (base->market_items.count(item))
+				maxFoodCount += base->market_items[item].max_stock;
 		}
 		PrintUserCmdText(client, L"|    Food: %u/%u", foodCount, maxFoodCount);
 


### PR DESCRIPTION
-incorrect handling of factory building
-unintuitive configs for refinery modules
-craft lists not being cleared on module destruction -craft lists not being selectable via numbers
-various optimizations, including food consumption and FactoryModule saving.