### PR TITLE
SDK fixes

### DIFF
--- a/Source/FLHookPluginSDK/headers/FLCoreServer.h
+++ b/Source/FLHookPluginSDK/headers/FLCoreServer.h
@@ -144,9 +144,9 @@ struct XSetManeuver
 struct XSetTarget
 {
 	uint iShip;
-	uint iSlot;
+	ushort iSlot;
 	uint iSpaceID;
-	uint iSubObjID;
+	ushort iSubObjID;
 };
 
 struct SSPObjUpdateInfo
@@ -155,7 +155,6 @@ struct SSPObjUpdateInfo
 	Quaternion vDir;
 	Vector vPos;
 	double fTimestamp;
-	float fDunno;
 	float throttle;
 	char cState;
 };


### PR DESCRIPTION
SetTarget iSlot and iSubObj are short values, and if read as uints, may contain junk data in the first 4 bytes
Removal of incorrect fDunno from SPObjUpdate