### PR TITLE
Change player dock broadcast from around the ship to around the base

### DIFF
--- a/Plugins/PluginUtilities/PluginUtilities.cpp
+++ b/Plugins/PluginUtilities/PluginUtilities.cpp
@@ -1122,17 +1122,14 @@ void ini_write_wstring(FILE *file, const string &parmname, wstring &in)
 }
 
 // Print message to all ships within the specific number of meters of the player.
-void PrintLocalUserCmdText(uint iClientID, const wstring &wscMsg, float fDistance)
+void PrintLocalMsgAroundObject(uint spaceObjId, const wstring &wscMsg, float fDistance)
 {
-	uint iShip;
-	pub::Player::GetShip(iClientID, iShip);
-
 	Vector pos;
 	Matrix rot;
-	pub::SpaceObj::GetLocation(iShip, pos, rot);
+	pub::SpaceObj::GetLocation(spaceObjId, pos, rot);
 
 	uint iSystem;
-	pub::Player::GetSystem(iClientID, iSystem);
+	pub::SpaceObj::GetSystem(spaceObjId, iSystem);
 
 	// For all players in system...
 	struct PlayerData *pPD = 0;
@@ -1158,6 +1155,14 @@ void PrintLocalUserCmdText(uint iClientID, const wstring &wscMsg, float fDistanc
 
 		PrintUserCmdText(iClientID2, L"%s", wscMsg.c_str());
 	}
+}
+
+void PrintLocalUserCmdText(uint iClientID, const wstring& wscMsg, float fDistance)
+{
+	uint iShip;
+	pub::Player::GetShip(iClientID, iShip);
+
+	PrintLocalMsgAroundObject(iShip, wscMsg, fDistance);
 }
 
 // Send a player to group message

--- a/Plugins/PluginUtilities/PluginUtilities.h
+++ b/Plugins/PluginUtilities/PluginUtilities.h
@@ -75,6 +75,7 @@ void FormatSendChat(uint iToClientID, const wstring &wscSender, const wstring &w
 void ini_get_wstring(INI_Reader &ini, wstring &wscValue);
 void ini_write_wstring(FILE *file, const string &parmname, wstring &in);
 void PrintLocalUserCmdText(uint iClientID, const wstring &wscMsg, float fDistance);
+void PrintLocalMsgAroundObject(uint spaceObjId, const wstring& wscMsg, float fDistance);
 void SendGroupChat(uint iFromClientID, const wstring &wscText);
 void Rotate180(Matrix &rot);
 void TranslateX(Vector &pos, Matrix &rot, float x);

--- a/Plugins/Public/base_plugin/Main.cpp
+++ b/Plugins/Public/base_plugin/Main.cpp
@@ -3240,11 +3240,15 @@ void Plugin_Communication_CallBack(PLUGIN_MESSAGE msg, void* data)
 		DESPAWN_SOLAR_STRUCT* info = reinterpret_cast<DESPAWN_SOLAR_STRUCT*>(data);
 		CreateSolar::DespawnSolarCallout(info);
 	}
-	else if (msg == CUSTOM_SPAWN_SOLAR)
+	else if (msg == CUSTOM_POB_DOCK_ALERT)
 	{
 		returncode = SKIPPLUGINS;
-		SPAWN_SOLAR_STRUCT* info = reinterpret_cast<SPAWN_SOLAR_STRUCT*>(data);
-		CreateSolar::CreateSolarCallout(info);
+		CUSTOM_POB_DOCK_ALERT_STRUCT* info = reinterpret_cast<CUSTOM_POB_DOCK_ALERT_STRUCT*>(data);
+		PlayerBase* pb = GetPlayerBaseForClient(info->client);
+		if (pb)
+		{
+			PrintLocalMsgAroundObject(CreateID(pb->nickname.c_str()), *info->msg, info->range);
+		}
 	}
 	return;
 }

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -566,11 +566,23 @@ namespace HkIServerImpl
 		uint landingClientId = HkGetClientIDByShip(pLand.iShip);
 		if (landingClientId && landingClientId == iClientID)
 		{
-			// Print out a message when a player ship docks.
+			// If docking on a base, print out a message when a player ship docks.
 			wstring wscMsg = L"%time Traffic control alert: %player has docked";
 			wscMsg = ReplaceStr(wscMsg, L"%time", GetTimeString(set_bLocalTime));
 			wscMsg = ReplaceStr(wscMsg, L"%player", (const wchar_t*)Players.GetActiveCharacterName(landingClientId));
-			PrintLocalUserCmdText(iClientID, wscMsg, set_iDockBroadcastRange);
+			const auto base = Universe::get_base(pLand.iTargetBase);
+			if (((string)base->cNickname).find("_proxy_base") != string::npos)
+			{
+				CUSTOM_POB_DOCK_ALERT_STRUCT info;
+				info.client = iClientID;
+				info.msg = &wscMsg;
+				info.range = set_iDockBroadcastRange;
+				Plugin_Communication(CUSTOM_POB_DOCK_ALERT, &info);
+			}
+			else
+			{
+				PrintLocalMsgAroundObject(base->lSpaceObjID, wscMsg, set_iDockBroadcastRange);
+			}
 		}
 		return true;
 	}

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -625,6 +625,7 @@ namespace HkIServerImpl
 
 	void DelayedDisconnect(uint client, uint ship)
 	{
+		returncode = DEFAULT_RETURNCODE;
 		Message::DelayedDisconnect(client);
 	}
 

--- a/Source/FLHookPluginSDK/headers/plugin.h
+++ b/Source/FLHookPluginSDK/headers/plugin.h
@@ -266,7 +266,8 @@ enum PLUGIN_MESSAGE
 	CUSTOM_CLOAK_CHECK = 56,
 	CUSTOM_RENAME_NOTIFICATION = 57,
 	CUSTOM_RESTART_NOTIFICATION = 58,
-	CUSTOM_CLOAK_ALERT = 60
+	CUSTOM_CLOAK_ALERT = 60,
+	CUSTOM_POB_DOCK_ALERT = 61
 };
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -448,6 +449,13 @@ struct CUSTOM_RENAME_NOTIFICATION_STRUCT
 struct CUSTOM_RESTART_NOTIFICATION_STRUCT
 {
 	wstring playerName;
+};
+
+struct CUSTOM_POB_DOCK_ALERT_STRUCT
+{
+	uint client;
+	float range;
+	wstring* msg;
 };
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In some circumstances, the player position was already set to 0,0,0. As such, we use the Base position itself.