### PR TITLE
Event: Minor rework

### DIFF
--- a/Plugins/Public/event/Main.cpp
+++ b/Plugins/Public/event/Main.cpp
@@ -69,7 +69,7 @@ struct TRADE_EVENT {
 	uint uEndBase;
 	bool bFLHookBase = false;
 	string sFLHookBaseName;
-	int iObjectiveMax;
+	int iObjectiveMax = INT32_MAX;
 	int iObjectiveCurrent = 0; // Always 0 to prevent having no data
 	uint uCommodityID;
 	bool bLimited = false; //Whether or not this is limited to a specific set of IDs
@@ -80,7 +80,7 @@ struct COMBAT_EVENT {
 	//Basic event settings
 	string sEventName;
 	string sURL;
-	int iObjectiveMax;
+	int iObjectiveMax = INT32_MAX;
 	int iObjectiveCurrent = 0; // Always 0 to prevent having no data	
 	//Combat event data
 	bool bPlayersOnly = false; // assume false
@@ -103,7 +103,7 @@ struct MINING_EVENT {
 	//Basic event settings
 	string sEventName;
 	string sURL;
-	int iObjectiveMax;
+	int iObjectiveMax = INT32_MAX;
 	int iObjectiveCurrent = 0; // Always 0 to prevent having no data
 	int iBonusCash;
 	//Mining settings
@@ -1338,7 +1338,7 @@ void HkTimerCheckKick()
 
 
 /// Hook for ship distruction. It's easier to hook this than the PlayerDeath one.
-void SendDeathMsg(const wstring &wscMsg, uint iSystem, uint iClientIDVictim, uint iClientIDKiller)
+void SendDeathMsg(const wstring &wscMsg, uint& iSystem, uint& iClientIDVictim, uint& iClientIDKiller)
 {
 	returncode = DEFAULT_RETURNCODE;
 

--- a/Plugins/Public/kill_tracker/Main.cpp
+++ b/Plugins/Public/kill_tracker/Main.cpp
@@ -367,7 +367,7 @@ inline float GetDamageDone(const DamageDoneStruct& damageDone)
 	return 0.0f;
 }
 
-void __stdcall SendDeathMessage(const wstring& message, uint system, uint clientVictim, uint clientKiller)
+void __stdcall SendDeathMessage(const wstring& message, uint& system, uint& clientVictim, uint& clientKiller)
 {
 	returncode = DEFAULT_RETURNCODE;
 	if (!clientVictim)
@@ -434,6 +434,7 @@ void __stdcall SendDeathMessage(const wstring& message, uint system, uint client
 		wstring inflictorName = reinterpret_cast<const wchar_t*>(Players.GetActiveCharacterName(i->second));
 		if (killerCounter == 0)
 		{
+			clientKiller = i->second; // override the killer ID to the top damage contributor for other plugins.
 			deathMessage = ReplaceStr(deathMessage, L"%killer", inflictorName);
 			deathMessage += L" (" + stows(itos(contributionPercentage)) + L"%)";
 		}
@@ -514,7 +515,7 @@ EXPORT PLUGIN_INFO* Get_PluginInfo()
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&LoadSettings, PLUGIN_LoadSettings, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&UserCmd_Process, PLUGIN_UserCmd_Process, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&AddDamageEntry, PLUGIN_HkCb_AddDmgEntry_AFTER, 0));
-	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&SendDeathMessage, PLUGIN_SendDeathMsg, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&SendDeathMessage, PLUGIN_SendDeathMsg, 5));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&DelayedDisconnect, PLUGIN_DelayedDisconnect, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&Disconnect, PLUGIN_HkIServerImpl_DisConnect, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&PlayerLaunch, PLUGIN_HkIServerImpl_PlayerLaunch, 0));

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -198,7 +198,7 @@ void HkTimer()
 
 /// Hook for ship distruction. It's easier to hook this than the PlayerDeath one.
 /// Drop a percentage of cargo + some loot representing ship bits.
-void SendDeathMsg(const wstring &wscMsg, uint iSystem, uint iClientIDVictim, uint iClientIDKiller)
+void SendDeathMsg(const wstring &wscMsg, uint& iSystem, uint& iClientIDVictim, uint& iClientIDKiller)
 {
 	returncode = NOFUNCTIONCALL;
 

--- a/Source/FLHook/HkCbDeath.cpp
+++ b/Source/FLHook/HkCbDeath.cpp
@@ -18,7 +18,7 @@ Send "Death: ..." chat-message
 
 void SendDeathMsg(const wstring &wscMsg, uint iSystemID, uint iClientIDVictim, uint iClientIDKiller)
 {
-	CALL_PLUGINS_V(PLUGIN_SendDeathMsg, , (const wstring&, uint, uint, uint), (wscMsg, iSystemID, iClientIDVictim, iClientIDKiller));
+	CALL_PLUGINS_V(PLUGIN_SendDeathMsg, , (const wstring&, uint&, uint&, uint&), (wscMsg, iSystemID, iClientIDVictim, iClientIDKiller));
 
 	// encode xml string(default and small)
 	// non-sys


### PR DESCRIPTION
Kill_Tracker now overrides the killer ID with the top damage contributor, allowing Event plugin to use it.

Event plugin now uses INT32_MAX as default value for objectiveMax variables.