### PR TITLE
Conn: Remove unnecessary data purging

### DIFF
--- a/Plugins/Public/conn_plugin/Main.cpp
+++ b/Plugins/Public/conn_plugin/Main.cpp
@@ -203,9 +203,6 @@ void StoreReturnPointForClient(unsigned int client)
 	{
 		HookExt::IniSetI(client, "conn.retsystembackup", connInfo[client].retSystemBackup);
 	}
-	connInfo[client].clientState = NONE;
-	connInfo[client].retBase = 0;
-	connInfo[client].retSystemBackup = 0;
 }
 
 void SimulateF1(uint client, uint baseId)


### PR DESCRIPTION
Transfer Flag is already cleared on line 380.
Clearing of the data should only even occur on character select/clearclientinfo