### PR TITLE
Fix dock message bug for good.

### DIFF
--- a/Plugins/Public/mobiledocking_plugin/Main.cpp
+++ b/Plugins/Public/mobiledocking_plugin/Main.cpp
@@ -808,9 +808,6 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iTargetID, 
 	uint client = HkGetClientIDByShip(iShip);
 	if (client && response == DOCK && dockPort == -1)
 	{
-		// If target not a player in FREIGHTER class ship, ignore request
-		returncode = SKIPPLUGINS;
-
 		uint iTargetType;
 		pub::SpaceObj::GetType(iTargetID, iTargetType);
 		if (!(iTargetType & (OBJ_CRUISER | OBJ_CAPITAL)))
@@ -859,6 +856,8 @@ int __cdecl Dock_Call(unsigned int const &iShip, unsigned int const &iTargetID, 
 			response = DOCK_DENIED;
 			return 0;
 		}
+
+		returncode = SKIPPLUGINS;
 
 		CUSTOM_CLOAK_CHECK_STRUCT cloakCheck;
 		cloakCheck.clientId = client;

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -58,6 +58,7 @@ float set_fMinCLootRoadkillSpeed = 25.0f;
 // set of ships which cannot use TradeLane, and are blocked
 // from forming on other ships to bypass the block
 unordered_set<uint> setLaneAndFormationBannedShips;
+bool supressDockMsg[255];
 /** A return code to indicate to FLHook if we want the hook processing to continue. */
 PLUGIN_RETURNCODE returncode;
 
@@ -360,6 +361,11 @@ namespace HkIEngine
 		}
 		if (response == DOCK && dockPort == -1)
 		{
+			if (supressDockMsg[iClientID])
+			{
+				supressDockMsg[iClientID] = false;
+				return 0;
+			}
 			wstring wscMsg = L"%time Traffic control alert: %player has docked";
 			wscMsg = ReplaceStr(wscMsg, L"%time", GetTimeString(set_bLocalTime));
 			wscMsg = ReplaceStr(wscMsg, L"%player", (const wchar_t*)Players.GetActiveCharacterName(iClientID));
@@ -451,6 +457,10 @@ namespace HkIServerImpl
 			return;
 		}
 
+		if (iType == 0)
+		{
+			supressDockMsg[iClientID] = true;
+		}
 		HyperJump::RequestCancel(iType, requestFrom, requestTo);
 	}
 

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -366,6 +366,13 @@ namespace HkIEngine
 				supressDockMsg[iClientID] = false;
 				return 0;
 			}
+			uint type;
+			pub::SpaceObj::GetType(iDockTarget, type);
+			if (!(type & (OBJ_STATION | OBJ_DOCKING_RING)))
+			{
+				return 0;
+			}
+
 			wstring wscMsg = L"%time Traffic control alert: %player has docked";
 			wscMsg = ReplaceStr(wscMsg, L"%time", GetTimeString(set_bLocalTime));
 			wscMsg = ReplaceStr(wscMsg, L"%player", (const wchar_t*)Players.GetActiveCharacterName(iClientID));

--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -354,11 +354,16 @@ namespace HkIEngine
 				response = DOCK_DENIED;
 				return 0;
 			}
-
-
 			SystemSensor::Dock_Call(iTypeID, iClientID);
 
 			return 0;
+		}
+		if (response == DOCK && dockPort == -1)
+		{
+			wstring wscMsg = L"%time Traffic control alert: %player has docked";
+			wscMsg = ReplaceStr(wscMsg, L"%time", GetTimeString(set_bLocalTime));
+			wscMsg = ReplaceStr(wscMsg, L"%player", (const wchar_t*)Players.GetActiveCharacterName(iClientID));
+			PrintLocalUserCmdText(iClientID, wscMsg, set_iDockBroadcastRange);
 		}
 		return 0;
 	}


### PR DESCRIPTION
PlayerCntl: move the message print to a separate check where dockPort == -1
MobileDock: move the returncode override to after it's confirmed the target is a player.