### PR TITLE
ClearQueue command for POBs added

### DIFF
--- a/Plugins/Public/base_plugin/FactoryModule.cpp
+++ b/Plugins/Public/base_plugin/FactoryModule.cpp
@@ -426,6 +426,18 @@ FactoryModule* FactoryModule::FindModuleByProductInProduction(PlayerBase* pb, ui
 	return nullptr;
 }
 
+void FactoryModule::ClearAllProductionQueues(PlayerBase* pb)
+{
+	for (auto& i : pb->modules)
+	{
+		FactoryModule* facModPtr = dynamic_cast<FactoryModule*>(i);
+		if (facModPtr)
+		{
+			facModPtr->ClearQueue();
+		}
+	}
+}
+
 void FactoryModule::StopAllProduction(PlayerBase* pb)
 {
 	for (auto& i : pb->modules)

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -258,6 +258,7 @@ public:
 	static FactoryModule* FactoryModule::FindModuleByProductInProduction(PlayerBase* pb, uint searchedProduct);
 	static const RECIPE* FactoryModule::GetFactoryProductRecipe(wstring& craftType, wstring& product);
 	static void FactoryModule::StopAllProduction(PlayerBase* pb);
+	static void FactoryModule::ClearAllProductionQueues(PlayerBase* pb);
 	static bool FactoryModule::IsFactoryModule(Module* module);
 
 	bool Paused = false;

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -1356,6 +1356,7 @@ namespace PlayerCommands
 	void PrintCraftHelpMenu(uint client)
 	{
 		PrintUserCmdText(client, L"/craft stopall - stops all production on the base");
+		PrintUserCmdText(client, L"/craft clearall - clears all production queues on the base");
 		PrintUserCmdText(client, L"/craft list - show all available craft lists");
 		PrintUserCmdText(client, L"/craft list <craftList/Nr> - list item recipes available for this crafting list");
 		PrintUserCmdText(client, L"/craft start <craftList/Nr> <name/itemNr> - adds selected item into the crafting queue");
@@ -1395,6 +1396,12 @@ namespace PlayerCommands
 		{
 			FactoryModule::StopAllProduction(base);
 			PrintUserCmdText(client, L"OK Factories stopped");
+			return;
+		}
+		if (cmd == L"clearall")
+		{
+			FactoryModule::ClearAllProductionQueues(base);
+			PrintUserCmdText(client, L"OK Craft queues cleared");
 			return;
 		}
 


### PR DESCRIPTION
Currently POBs have no command to clear pending queues of factories without stopping currently ongong recipes as well. This is a fast fix until I come up with a command targeting a specific factory.