### PR TITLE
FLHook core update

### DIFF
--- a/FLHook.sln
+++ b/FLHook.sln
@@ -99,6 +99,9 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DSAceSrv Plugin", "Plugins\Public\dsacesrv_discovery\dsace_plugin.vcxproj", "{209E8482-B6B8-4CF8-B117-B93BE1B9E72D}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BountyScan", "Plugins\Public\bountyscan\BountyScan.vcxproj", "{985915AF-E158-45E7-BBDD-BCD4642E5574}"
+	ProjectSection(ProjectDependencies) = postProject
+		{81D33B95-1DDD-4F58-A24C-E2EC4A143DD0} = {81D33B95-1DDD-4F58-A24C-E2EC4A143DD0}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Source/FLHook.vcxproj
+++ b/Source/FLHook.vcxproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -68,7 +68,7 @@ copy /Y  $(OutDir)$(TargetName).lib  $(SolutionDir)\Source\FLHookPluginSDK\libs\
     </CustomBuildStep>
     <ClCompile>
       <AdditionalOptions>-D_SCL_SECURE_NO_WARNINGS %(AdditionalOptions)</AdditionalOptions>
-      <Optimization>Full</Optimization>
+      <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <ExceptionHandling>Async</ExceptionHandling>

--- a/Source/FLHook/HkCbIServerImpl.cpp
+++ b/Source/FLHook/HkCbIServerImpl.cpp
@@ -50,7 +50,7 @@ namespace HkIServerImpl
 	{
 		{ProcessPendingCommands,		50,					0},
 		{HkTimerCheckKick,			1000,					0},
-		{HkTimerNPCAndF1Check,			50,					0},
+		{HkTimerNPCAndF1Check,			100,					0},
 	};
 
 	int __stdcall Update(void)
@@ -64,11 +64,12 @@ namespace HkIServerImpl
 		}
 
 		// call timers
+		mstime currTime = timeInMS();
 		for (uint i = 0; (i < sizeof(Timers) / sizeof(TIMER)); i++)
 		{
-			if ((timeInMS() - Timers[i].tmLastCall) >= Timers[i].tmIntervallMS)
+			if ((currTime - Timers[i].tmLastCall) >= Timers[i].tmIntervallMS)
 			{
-				Timers[i].tmLastCall = timeInMS();
+				Timers[i].tmLastCall = currTime;
 				Timers[i].proc();
 			}
 		}

--- a/Source/FLHook/HkFuncTools.cpp
+++ b/Source/FLHook/HkFuncTools.cpp
@@ -216,9 +216,10 @@ HK_ERROR HkResolveShortCut(const wstring &wscShortcut, uint &_iClientID)
 
 uint HkGetClientIDByShip(uint iShip)
 {
-	const CShip* cobj = reinterpret_cast<CShip*>(CObject::Find(iShip, CObject::CSHIP_OBJECT));
+	CShip* cobj = reinterpret_cast<CShip*>(CObject::Find(iShip, CObject::CSHIP_OBJECT));
 	if (cobj)
 	{
+		cobj->Release();
 		return cobj->GetOwnerPlayer();
 	}
 	return 0;

--- a/Source/FLHook/HkInit.cpp
+++ b/Source/FLHook/HkInit.cpp
@@ -305,6 +305,11 @@ bool InitHookExports()
 	ReadProcMem(pAddress, szRepFreeFixOld, 5);
 	WriteProcMem(pAddress, szNOPs, 5);
 
+	// jump past a redundant XOR statement
+	pAddress = SRV_ADDR(0x61D6);
+	char szJumpXor[1] = { '\x0D' };
+	WriteProcMem(pAddress, szJumpXor, sizeof(szJumpXor));
+
 	// patch pub::Save method
 	pAddress = SRV_ADDR(0x7EFA8);
 	char szNop[2] = { '\x90', '\x90' };
@@ -317,6 +322,11 @@ bool InitHookExports()
 	char szDivertJump[] = { '\x6F' };
 
 	WriteProcMem(pAddress, szDivertJump, 1);
+
+	// jump out of the crash trap in TradeLane/SPObjUpdate related code
+	pAddress = (char*)hModCommon + 0xF24A0;
+	char szSkipCrash[2] = { '\xEB', '\x28' };
+	WriteProcMem(pAddress, szSkipCrash, 2);
 
 	// install hook at new address
 	pAddress = SRV_ADDR(0x78B39);

--- a/Source/FLHookPluginSDK/headers/FLCoreServer.h
+++ b/Source/FLHookPluginSDK/headers/FLCoreServer.h
@@ -17,6 +17,8 @@
 #include <list>
 #include <vector>
 #include <map>
+#include <unordered_map>
+#include <unordered_set>
 #include "flmap.h"
 
 #include "FLCoreDefs.h"

--- a/Source/FLHookPluginSDK/headers/plugin.h
+++ b/Source/FLHookPluginSDK/headers/plugin.h
@@ -335,33 +335,33 @@ struct CUSTOM_BASE_BEAM_STRUCT
 {
 	uint iClientID;
 	uint iTargetBaseID;
-	bool bBeamed;
+	bool bBeamed = false;
 };
 
 struct CUSTOM_BASE_IS_DOCKED_STRUCT
 {
 	uint iClientID;
-	uint iDockedBaseID;
+	uint iDockedBaseID = 0;
 };
 
 struct CUSTOM_BASE_IS_IT_POB_STRUCT
 {
 	uint iBase;
-	bool bAnswer;
+	bool bAnswer = false;
 };
 
 struct CLIENT_CLOAK_STRUCT
 {
 	uint iClientID;
-	bool isChargingCloak;
-	bool isCloaked;
+	bool isChargingCloak = false;
+	bool isCloaked = false;
 };
 
 struct COMBAT_DAMAGE_OVERRIDE_STRUCT
 {
 	uint iMunitionID;
 	uint iTargetTypeID;
-	float fDamageMultiplier;
+	float fDamageMultiplier = 1.0;
 };
 
 const enum JUMP_TYPE {


### PR DESCRIPTION
-Fix CObject::Find reference counter remaining unreleased
-Cross plugin structs are now initializing with default values
-Apply a crash prevention patch to common.dll
-Apply a minor optimization to server.dll
-Unordered_map and _set are now included in FLCoreServer.h
-Added missing dependency to HookExtension plugin for BountyHunt
-FLHook core can now compile in debug mode.
-Minor optimizations