### PR TITLE
POB: Optimizations to damage-taking code, other updates

### DIFF
--- a/Plugins/Public/base_plugin/ClientCommands.cpp
+++ b/Plugins/Public/base_plugin/ClientCommands.cpp
@@ -191,7 +191,13 @@ void SendBaseStatus(uint client, PlayerBase* base)
 	{
 		base_status += L"<TEXT>Hit Points: Indestructible</TEXT><PARA/>";
 	}
-	base_status += L"<TEXT>Population: " + Int64ToPrettyStr((INT64)base->HasMarketItem(set_base_crew_type)) + L"</TEXT><PARA/>";
+	uint population = 0;
+	for (uint hash : humanCargoList)
+	{
+		population += base->HasMarketItem(hash);
+	}
+	base_status += L"<TEXT>Crew: " + Int64ToPrettyStr((INT64)base->HasMarketItem(set_base_crew_type)) + L"</TEXT><PARA/>";
+	base_status += L"<TEXT>Total population: " + Int64ToPrettyStr((INT64)population) + L"</TEXT><PARA/>";
 
 	if (single_vulnerability_window)
 	{

--- a/Plugins/Public/base_plugin/Main.h
+++ b/Plugins/Public/base_plugin/Main.h
@@ -145,8 +145,8 @@ public:
 	// If true, do not take damage
 	bool dont_rust;
 
-	// The list of goods and usage of goods per minute for the autosys effect
-	map<uint, uint> mapAutosysGood;
+	bool wasDamagedSinceLastUpdate;
+	bool undergoingDestruction;
 
 	// The list of goods and usage of goods per minute for the autosys effect
 	map<uint, uint> mapHumansysGood;
@@ -309,7 +309,6 @@ public:
 
 	float GetAttitudeTowardsClient(uint client, bool emulated_siege_mode = false);
 	void SyncReputationForBase();
-	void SiegeModChainReaction(uint client);
 	void SyncReputationForBaseObject(uint space_obj);
 
 	void SpaceObjDamaged(uint space_obj, uint attacking_space_obj, float curr_hitpoints, float new_hitpoints);
@@ -319,6 +318,9 @@ public:
 
 	// The base nickname
 	string nickname;
+
+	// Reference to the base's CSolar object
+	CSolar* baseCSolar;
 
 	// The base affiliation
 	uint affiliation;
@@ -401,11 +403,10 @@ public:
 	unordered_set<uint> hostile_factions;
 
 	// List of ships that are hostile to this base
-	unordered_map<wstring, wstring> hostile_tags;
-	unordered_map<wstring, float> hostile_tags_damage;
+	unordered_set<wstring> hostile_tags;
 
 	// List of ships that are permanently hostile to this base
-	list<wstring> perma_hostile_tags;
+	unordered_set<wstring> perma_hostile_tags;
 
 	// Modules for base
 	vector<Module*> modules;
@@ -433,9 +434,6 @@ public:
 
 	int logic;
 	int invulnerable;
-
-	//last player attacker
-	wstring last_attacker;
 
 	uint lastVulnerabilityWindowChange = 0;
 
@@ -679,7 +677,7 @@ extern int construction_credit_cost;
 extern uint set_damage_per_10sec;
 
 /// Damage to the base every tick
-extern uint set_damage_per_tick;
+extern float set_damage_per_tick;
 
 /// Additional damage penalty for stations without proper crew
 extern float no_crew_damage_multiplier;

--- a/Plugins/Public/base_plugin/PlayerCommands.cpp
+++ b/Plugins/Public/base_plugin/PlayerCommands.cpp
@@ -877,7 +877,7 @@ namespace PlayerCommands
 		}
 
 
-		base->perma_hostile_tags.emplace_back(tag);
+		base->perma_hostile_tags.insert(tag);
 
 		// Logging
 		wstring thecharname = (const wchar_t*)Players.GetActiveCharacterName(client);
@@ -909,13 +909,13 @@ namespace PlayerCommands
 			PrintUserCmdText(client, L"ERR No tag");
 		}
 
-		if (find(base->perma_hostile_tags.begin(), base->perma_hostile_tags.end(), tag) == base->perma_hostile_tags.end())
+		if (!base->perma_hostile_tags.count(tag))
 		{
 			PrintUserCmdText(client, L"ERR Tag does not exist");
 			return;
 		}
 
-		base->perma_hostile_tags.remove(tag);
+		base->perma_hostile_tags.erase(tag);
 
 		// Logging
 		wstring thecharname = (const wchar_t*)Players.GetActiveCharacterName(client);
@@ -941,8 +941,8 @@ namespace PlayerCommands
 			return;
 		}
 
-		foreach(base->perma_hostile_tags, wstring, i)
-			PrintUserCmdText(client, L"%s", i->c_str());
+		for(auto& hostileTag : base->perma_hostile_tags)
+			PrintUserCmdText(client, L"%s", hostileTag.c_str());
 		PrintUserCmdText(client, L"OK");
 	}
 
@@ -1871,7 +1871,7 @@ namespace PlayerCommands
 
 					wstring charname = (const wchar_t*)Players.GetActiveCharacterName(client);
 					const GoodInfo* gi = GoodList::find_by_id(i.first);
-					BaseLogging("Base %s: player %s changed price of %s to %f", wstos(base->basename).c_str(), wstos(charname).c_str(), wstos(HkGetWStringFromIDS(gi->iIDSName)).c_str(), money);
+					BaseLogging("Base %s: player %s changed price of %s to %d", wstos(base->basename).c_str(), wstos(charname).c_str(), wstos(HkGetWStringFromIDS(gi->iIDSName)).c_str(), money);
 					return;
 				}
 			}
@@ -1995,6 +1995,13 @@ namespace PlayerCommands
 			PrintUserCmdText(client, L"WARNING, CREW COUNT TOO LOW");
 		}
 		PrintUserCmdText(client, L"Crew: %u onboard", crewItemCount);
+
+		uint populationCount = 0;
+		for (uint hash : humanCargoList)
+		{
+			populationCount += base->HasMarketItem(hash);
+		}
+		PrintUserCmdText(client, L"Total population: %u onboard", populationCount);
 
 		PrintUserCmdText(client, L"Crew supplies:");
 		for (uint item : set_base_crew_consumption_items)


### PR DESCRIPTION
-POBs now calculate wear and tear much more efficiently
-Fix specific interactions with MobileDocking plugin
-Fix players who logged out in space being beamed back onto the POB
-POBs now explode immediately upon reaching 0 health
-Removed a bunch of deprecated siege-mode related code
-Fixed price update logging
-Non-crew POB population added to F9 menu and /base supplies
-Code cleanup